### PR TITLE
update to time format for status command

### DIFF
--- a/master_controller/master_controller.py
+++ b/master_controller/master_controller.py
@@ -639,9 +639,15 @@ class HAPIListener(TelnetHandler):
         data = data + '  RTUs Online: ' + str(len(self.the_rtus)) + '\n'
         data = data + '  Timestamp: ' + str(datetime.datetime.now())[0:19] + '\n'
         uptime = datetime.datetime.now() - launch_time
+        '''
         days = uptime.days
         hours = divmod(uptime.seconds, 3600)[0]
         minutes = divmod(uptime.seconds, 60)[0]
+        '''
+        seconds = uptime.seconds
+        minutes = divmod(seconds, 60)[0]
+        hours = divmod(minutes, 60)[0]
+        days = divmod(hours, 24)[0]
         uptime_str = "This listener has been online for " + str(days) + " days, " + str(hours) + " hours and " + str(minutes) + " minutes."
         data = data + '  Uptime: ' + uptime_str + '\n'
         #data = data + '  Copyright 2016, Maya Culpa, LLC\n'


### PR DESCRIPTION
Status command was displaying the uptime as: Uptime: This listener has been online for 0 days, 9 hours and 556 minutes.
as was counting total uptime minutes and not seconds x 60
Changed time format so uptime would display as: Uptime: This listener has been online for 0 days, 9 hours and 26 minutes.