### PR TITLE
Refactor bcd conversion routines of SDL-DS3231.py

### DIFF
--- a/src/smart_module/SDL_DS3231.py
+++ b/src/smart_module/SDL_DS3231.py
@@ -4,12 +4,12 @@
 # SwitchDoc Labs 12/19/2014
 # V 1.2
 # only works in 24 hour mode
-# now includes reading and writing the AT24C32 included on the SwitchDoc Labs 
-#	DS3231 / AT24C32 Module (www.switchdoc.com
+# now includes reading and writing the AT24C32 included on the SwitchDoc Labs
+# DS3231 / AT24C32 Module (www.switchdoc.com)
 
 
 #encoding: utf-8
- 
+
 # Copyright (C) 2013 @XiErCh
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -31,8 +31,8 @@
 # SOFTWARE.
 
 from datetime import datetime
-
 import time
+
 import smbus
 
 
@@ -79,8 +79,6 @@ class SDL_DS3231():
     _REG_YEAR = 0x06
     _REG_CONTROL = 0x07
 
-
-
     ###########################
     # DS3231 Code
     ###########################
@@ -89,11 +87,9 @@ class SDL_DS3231():
         self._addr = addr
         self._at24c32_addr = at24c32_addr
 
-
     def _write(self, register, data):
         #print "addr =0x%x register = 0x%x data = 0x%x %i " % (self._addr, register, data,_bcd_to_int(data))
         self._bus.write_byte_data(self._addr, register, data)
-
 
     def _read(self, data):
 
@@ -101,39 +97,29 @@ class SDL_DS3231():
         #print "addr = 0x%x data = 0x%x %i returndata = 0x%x %i " % (self._addr, data, data, returndata, _bcd_to_int(returndata))
         return returndata
 
-
-
-
     def _read_seconds(self):
         return _bcd_to_int(self._read(self._REG_SECONDS)& 0x7F)   # wipe out the oscillator on bit
-
 
     def _read_minutes(self):
         return _bcd_to_int(self._read(self._REG_MINUTES))
 
-
     def _read_hours(self):
         d = self._read(self._REG_HOURS)
-	if (d == 0x64):
-		d = 0x40
+        if (d == 0x64):
+            d = 0x40
         return _bcd_to_int(d & 0x3F)
-
 
     def _read_day(self):
         return _bcd_to_int(self._read(self._REG_DAY))
 
-
     def _read_date(self):
         return _bcd_to_int(self._read(self._REG_DATE))
-
 
     def _read_month(self):
         return _bcd_to_int(self._read(self._REG_MONTH))
 
-
     def _read_year(self):
         return _bcd_to_int(self._read(self._REG_YEAR))
-
 
     def read_all(self):
         """Return a tuple such as (year, month, date, day, hours, minutes,
@@ -143,7 +129,6 @@ class SDL_DS3231():
                 self._read_day(), self._read_hours(), self._read_minutes(),
                 self._read_seconds())
 
-
     def read_str(self):
         """Return a string such as 'YY-DD-MMTHH-MM-SS'.
         """
@@ -151,14 +136,12 @@ class SDL_DS3231():
                 self._read_month(), self._read_date(), self._read_hours(),
                 self._read_minutes(), self._read_seconds())
 
-
     def read_datetime(self, century=21, tzinfo=None):
         """Return the datetime.datetime object.
         """
         return datetime((century - 1) * 100 + self._read_year(),
                 self._read_month(), self._read_date(), self._read_hours(),
                 self._read_minutes(), self._read_seconds(), 0, tzinfo=tzinfo)
-
 
     def write_all(self, seconds=None, minutes=None, hours=None, day=None,
             date=None, month=None, year=None, save_as_24h=True):
@@ -169,7 +152,7 @@ class SDL_DS3231():
         if seconds is not None:
             if seconds < 0 or seconds > 59:
                 raise ValueError('Seconds is out of range [0,59].')
-	    seconds_reg = _int_to_bcd(seconds)
+            seconds_reg = _int_to_bcd(seconds)
             self._write(self._REG_SECONDS, seconds_reg)
 
         if minutes is not None:
@@ -202,49 +185,40 @@ class SDL_DS3231():
                 raise ValueError('Day is out of range [1,7].')
             self._write(self._REG_DAY, _int_to_bcd(day))
 
-
     def write_datetime(self, dt):
         """Write from a datetime.datetime object.
         """
         self.write_all(dt.second, dt.minute, dt.hour,
                 dt.isoweekday(), dt.day, dt.month, dt.year % 100)
 
-
     def write_now(self):
         """Equal to DS3231.write_datetime(datetime.datetime.now()).
         """
         self.write_datetime(datetime.now())
 
-
-
     def getTemp(self):
-   	byte_tmsb = self._bus.read_byte_data(self._addr,0x11)
-   	byte_tlsb = bin(self._bus.read_byte_data(self._addr,0x12))[2:].zfill(8)
-   	return byte_tmsb+int(byte_tlsb[0])*2**(-1)+int(byte_tlsb[1])*2**(-2)
+        byte_tmsb = self._bus.read_byte_data(self._addr,0x11)
+        byte_tlsb = bin(self._bus.read_byte_data(self._addr,0x12))[2:].zfill(8)
+        return byte_tmsb+int(byte_tlsb[0])*2**(-1)+int(byte_tlsb[1])*2**(-2)
 
     ###########################
     # AT24C32 Code
     ###########################
 
     def set_current_AT24C32_address(self,address):
-	a1=address/256;
-  	a0=address%256;
-  	self._bus.write_i2c_block_data(self._at24c32_addr,a1,[a0])
+        a1=address/256;
+        a0=address%256;
+        self._bus.write_i2c_block_data(self._at24c32_addr,a1,[a0])
 
-	
     def read_AT24C32_byte(self, address):
         #print "i2c_address =0x%x eepromaddress = 0x%x  " % (self._at24c32_addr, address)
 
         self.set_current_AT24C32_address(address)
-	return self._bus.read_byte(self._at24c32_addr)
-
-	
+        return self._bus.read_byte(self._at24c32_addr)
 
     def write_AT24C32_byte(self, address, value):
         #print "i2c_address =0x%x eepromaddress = 0x%x value = 0x%x %i " % (self._at24c32_addr, address, value, value)
-	
-
-	a1=address/256;
-  	a0=address%256;
-  	self._bus.write_i2c_block_data(self._at24c32_addr,a1,[a0, value])
-	time.sleep(0.20)
+        a1=address/256;
+        a0=address%256;
+        self._bus.write_i2c_block_data(self._at24c32_addr,a1,[a0, value])
+        time.sleep(0.20)

--- a/src/smart_module/SDL_DS3231.py
+++ b/src/smart_module/SDL_DS3231.py
@@ -39,7 +39,8 @@ import smbus
 def _bcd_to_int(bcd, n=2):
     """Decode n least significant packed binary coded decimal digits to binary.
     Return binary result.
-    n defaults to 2 (BCD digits)."""
+    n defaults to 2 (BCD digits).
+    n=0 decodes all digits."""
     return int(('%x' % bcd)[-n:])
 
 
@@ -56,17 +57,45 @@ def _bcd_to_int(bcd, n=2):
     return x
 
 
-def _int_to_bcd(n):
-    """Encode a one or two digits number to the BCD.
+def _int_to_bcd(x, n=2):
     """
+    Encode the n least significant decimal digits of x
+    to packed binary coded decimal (BCD).
+    Return BCD value.
+    n defaults to 2 (digits).
+    n=0 encodes all digits.
+    """
+
+    return int(('%d' % x)[-n:], 0x10)
+
+
+def _int_to_bcd(x, n=2):
+    """
+    Encode the n least significant decimal digits of x
+    to packed binary coded decimal (BCD).
+    Return BCD value.
+    n defaults to 2 (digits).
+    n=0 encodes all digits.
+    """
+
+    return int(str(x)[-n:], 0x10)
+
+
+def _int_to_bcd(x, n=2):
+    """
+    Encode the n least significant decimal digits of x
+    to packed binary coded decimal (BCD).
+    Return BCD value.
+    n defaults to 2 (digits).
+    """
+
     bcd = 0
-    for i in (n // 10, n % 10):
-        for p in (8, 4, 2, 1):
-            if i >= p:
-                bcd += 1
-                i -= p
-            bcd <<= 1
-    return bcd >> 1
+    m = 1
+    for _ in range(n):
+        x, digit = divmod(x, 10)
+        bcd += m * digit
+        m *= 0x10
+    return bcd
 
 
 class SDL_DS3231():

--- a/src/smart_module/SDL_DS3231.py
+++ b/src/smart_module/SDL_DS3231.py
@@ -36,17 +36,24 @@ import time
 import smbus
 
 
-def _bcd_to_int(bcd):
-    """Decode a 2x4bit BCD to a integer.
-    """
-    out = 0
-    for d in (bcd >> 4, bcd):
-        for p in (1, 2, 4 ,8):
-            if d & 1:
-                out += p
-            d >>= 1
-        out *= 10
-    return out / 10
+def _bcd_to_int(bcd, n=2):
+    """Decode n least significant packed binary coded decimal digits to binary.
+    Return binary result.
+    n defaults to 2 (BCD digits)."""
+    return int(('%x' % bcd)[-n:])
+
+
+def _bcd_to_int(bcd, n=2):
+    """Decode n least significant packed binary coded decimal digits to binary.
+    Return binary result.
+    n defaults to 2 (BCD digits)."""
+    x = 0
+    m = 1
+    for _ in range(n):
+        bcd, digit = divmod(bcd, 1<<4)
+        x += m * digit
+        m *= 10
+    return x
 
 
 def _int_to_bcd(n):


### PR DESCRIPTION
This is an unusual pull request in that you should destroy some of it.

There are two versions of _bcd_to_int(). Keep the version that is easiest for you to understand. Delete the other version.

There are three versions of _int_to_bcd(). Keep the version that is easiest for you to understand. Delete the other versions.

