### PR TITLE
MQTT Support for NodeMCU

### DIFF
--- a/src/dumb_module/arduino/hapinode/hapi_mqtt.ino
+++ b/src/dumb_module/arduino/hapinode/hapi_mqtt.ino
@@ -1,0 +1,253 @@
+#include <Arduino.h>
+
+/*
+#*********************************************************************
+#Copyright 2016 Maya Culpa, LLC
+#
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#*********************************************************************
+
+HAPI Remote Terminal Unit Firmware Code v3.0.0
+Authors: Tyler Reed, Mark Miller
+ESP Modification: John Archbold
+
+Sketch Date: May 2nd 2017
+Sketch Version: v3.0.0
+Implement of MQTT-based HAPInode (HN) for use in Monitoring and Control
+Implements mDNS discovery of MQTT broker
+Implements definitions for
+  ESP-NodeMCU
+  ESP8266
+  WROOM32
+Communications Protocol
+  WiFi
+Communications Method
+  MQTT        Listens for messages on Port 1883
+*/
+
+void(* resetFunc) (void) = 0; //declare reset function @ address
+
+boolean sendMQTTStatus(void){
+
+  StaticJsonBuffer<128> hn_topic_status;                   // Status data for this HN
+  JsonObject& status_topic = hn_topic_status.createObject();
+
+// Publish current status
+  // Identify HAPInode 
+  status_topic["AssetId"] = HN_id;
+  // Returns the current status of the HN itself
+  // Includes firmware version, MAC address, IP Address, Free RAM and Idle Mode
+  status_topic["FW"] = HAPI_FW_VERSION;
+  status_topic["DIO"] = String(NUM_DIGITAL);
+  status_topic["AIO"] = String(NUM_ANALOG);
+  status_topic["Free SRAM"] = String(freeRam()) + "k";
+  if (idle_mode == false){
+    status_topic["Idle"] = "False";
+  }else{
+    status_topic["Idle"] = "True";
+  }
+  status_topic.printTo(MQTTOutput, 128);          // MQTT JSON string is max 96 bytes
+  Serial.println(MQTTOutput);
+
+    // PUBLISH to the MQTT Broker
+  if (MQTTClient.publish(mqtt_topic_status, MQTTOutput)) {
+    return true;
+  }
+  // If the message failed to send, try again, as the connection may have broken.
+  else {
+    Serial.println("Status Message failed to publish. Reconnecting to MQTT Broker and trying again .. ");
+    if (MQTTClient.connect(clientID, MQTT_broker_username, MQTT_broker_password)) {
+      Serial.println("reconnected to MQTT Broker!");
+      delay(100); // This delay ensures that client.publish doesn't clash with the client.connect call
+      if (MQTTClient.publish(mqtt_topic_status, MQTTOutput)) {
+        return true;
+      }
+      else {
+        Serial.println("Status Message failed to publish after one retry.");
+        return false;
+      }
+    }
+    else {
+      Serial.println("Connection to MQTT Broker failed...");
+      return false;
+    }
+  }
+}
+
+boolean sendAllMQTTAssets(void) {
+//Process digital pins
+  for (int x = 0; x < NUM_DIGITAL; x++) {
+    if (pinControl[x] > 0) {
+      if (pinControl[x] < 5) {
+        while (!(sendMQTTAsset(SENSORID_D_PIN, x)));  // Until it is sent
+      }
+    }
+  }
+//Process analog pins
+  for (int x = 0; x < NUM_ANALOG; x++) {
+    while (!(sendMQTTAsset(SENSORID_A_PIN, x+NUM_DIGITAL)));  // Until it is sent
+  }
+// Process Custom Functions
+  for (int x = 0; x < CUSTOM_FUNCTIONS; x++) {
+    while (!(sendMQTTAsset(SENSORID_FN, x)));  // Until it is sent
+  }
+  return true;
+}
+
+boolean sendMQTTAsset(int SensorIdx, int Number) {
+  //For custom functions
+  FuncDef f;
+  float funcVal = -1.0;
+  StaticJsonBuffer<128> hn_topic_asset;                   // Sensor data for this HN
+  JsonObject& asset_topic = hn_topic_asset.createObject();
+  asset_topic["AssetId"] = HN_id;
+
+  // Assembles a response with values from pins and custom functions
+  // Returns a JSON string  ("pinnumber":value,"custom function abbreviation":value}
+
+//  if ((SensorIdx == SENSORID_D_PIN) || (SensorIdx == SENSORID_A_PIN)) {
+    asset_topic["SId"] = String(SensorIdx) + "." + String(Number);
+//  }
+//  else {
+//    asset_topic["SId"] = String(SensorIdx);
+//  }
+
+  switch(SensorIdx) {
+    case SENSORID_D_PIN:
+      asset_topic["name"] =  "DIO";
+      asset_topic["unit"] =  "";
+//      asset_topic["virtual"] =  "0";
+//      asset_topic["context"] =  "Sensor";
+//      asset_topic["system"] =  "node";
+//      asset_topic["enabled"] =  "1";
+      asset_topic["data"] =  (String)digitalRead(Number);
+      break;
+    case SENSORID_A_PIN:
+      asset_topic["name"] =  "AIO";
+      asset_topic["unit"] =  "";
+//      asset_topic["virtual"] =  "0";
+//      asset_topic["context"] =  "Sensor";
+//      asset_topic["system"] =  "node";
+//      asset_topic["enabled"] =  "1";
+      asset_topic["data_field"] =  (String)analogRead(Number);
+      break;
+    case SENSORID_FN:
+      f = HapiFunctions[Number];
+      asset_topic["name"] =  (String)f.fName;
+      asset_topic["unit"] =  (String)f.fUnit;
+//      asset_topic["virtual"] =  "0";
+//      asset_topic["context"] =  "Sensor";
+//      asset_topic["system"] =  "node";
+//      asset_topic["enabled"] =  "1";
+      funcVal = f.fPtr(Number);
+      asset_topic["data"] =  String((int)funcVal);
+      break;
+    default:
+      break;
+  }
+
+  asset_topic.printTo(MQTTOutput, 128);          // MQTT JSON string is max 96 bytes
+  Serial.println(MQTTOutput);
+
+// PUBLISH to the MQTT Broker
+  if (MQTTClient.publish(mqtt_topic_asset, MQTTOutput)) {
+    return true;
+  }
+// If the message failed to send, try again, as the connection may have broken.
+  else {
+    Serial.println("Send Asset Message failed. Reconnecting to MQTT Broker and trying again .. ");
+    if (MQTTClient.connect(clientID, MQTT_broker_username, MQTT_broker_password)) {
+      Serial.println("reconnected to MQTT Broker!");
+      delay(100); // This delay ensures that client.publish doesn't clash with the client.connect call
+      if (MQTTClient.publish(mqtt_topic_asset, MQTTOutput)) {
+        return true;
+      }
+      else {
+        Serial.println("Send Asset Message failed after one retry.");
+        return false;        
+      }
+    }
+    else {
+      Serial.println("Connection to MQTT Broker failed...");
+      return false;
+    }
+  }
+}
+
+void MQTTcallback(char* topic, byte* payload, unsigned int length) {
+
+  int i, j, k;
+  const char* AssetId = "WrongId";
+  const char* Command = "NoCommand";
+  StaticJsonBuffer<200> hn_topic_command;            // Parsing buffer
+
+  Serial.print("Topic: ");
+  Serial.print(topic);
+  Serial.print(" Length: ");
+  Serial.println(length);
+  Serial.print("Raw payload: ");
+  for(i = 0; i < length; i++){
+    Serial.print((char)payload[i]);
+    MQTTInput[i] = (char)payload[i];
+  }
+  MQTTInput[i] = 0x00;
+  Serial.print(" buffer: ");  
+  Serial.print(MQTTInput);
+  Serial.println();
+
+  //Parse the topic data
+  JsonObject& command_topic = hn_topic_command.parseObject(MQTTInput);
+  if (!command_topic.success())
+  {
+    Serial.println("parseObject() failed");
+    return;
+  } else {
+    Serial.println("Parsing .. ");
+    for (JsonObject::iterator it=command_topic.begin(); it!=command_topic.end(); ++it)
+    {
+      Serial.print(it->key);
+      Serial.print(":");
+      Serial.println(it->value.asString());
+    }
+       
+    if (command_topic.containsKey("AssetId")) {
+      AssetId = command_topic["AssetId"];
+    }
+
+    if (command_topic.containsKey("Cmnd")) {
+      Command = command_topic["Cmnd"];
+    }
+ 
+    if (strcmp(AssetId, hostString) == 0) {
+      if (strcmp(topic, "COMMAND/") == 0) {
+        if (strcmp(Command, "assets") == 0) sendAllMQTTAssets();
+        if (strcmp(Command, "status") == 0) sendMQTTStatus();
+      }
+      else if (strcmp(topic, "EXCEPTION/") == 0) {
+      }
+    /* 
+    else if (strcmp(topic, "STATUS/QUERY") == 0) {
+      if (strcmp(AssetId, hostString) == 0) sendMQTTStatus();
+      Serial.print("Found STATUS/QUERY = ");
+      Serial.println(AssetId);
+    }
+    else if (strcmp(topic, "ASSET/QUERY") == 0) {
+      if (strcmp(AssetId, hostString) == 0) sendAllMQTTAssets();
+      Serial.print("Found ASSET/QUERY = ");
+      Serial.println(AssetId);
+    }
+    */
+    }
+  }
+}

--- a/src/dumb_module/arduino/hapinode/hapi_sensors.ino
+++ b/src/dumb_module/arduino/hapinode/hapi_sensors.ino
@@ -1,0 +1,236 @@
+#include <Arduino.h>
+
+/*
+#*********************************************************************
+#Copyright 2016 Maya Culpa, LLC
+#
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#*********************************************************************
+
+HAPI Remote Terminal Unit Firmware Code v3.0.0
+Authors: Tyler Reed, Mark Miller
+ESP Modification: John Archbold
+
+Sketch Date: May 2nd 2017
+Sketch Version: v3.0.0
+Implement of MQTT-based HAPInode (HN) for use in Monitoring and Control
+Implements mDNS discovery of MQTT broker
+Implements definitions for 
+  ESP-NodeMCU
+  ESP8266
+  WROOM32
+Communications Protocol
+  WiFi
+Communications Method
+  MQTT        Listens for messages on Port 1883
+*/
+
+void setupSensors(void){
+  int i;
+  // Initialize Digital Pins for Input or Output - From the arrays pinControl and pinDefaults
+  for (int x = 0; x < (NUM_DIGITAL+NUM_ANALOG); x++) {
+    if (pinControl[x] == 1) {
+      pinMode(x, INPUT); // Digital Input
+    }
+    if (pinControl[x] == 2) {
+      pinMode(x, INPUT_PULLUP); // Digital Inputs w/ Pullup Resistors
+    }
+    if (pinControl[x] == 3) {
+      pinMode(x, OUTPUT); // Digital Outputs
+      if (pinDefaults[x] == 0) {
+        digitalWrite(x, LOW);
+      }
+      else{
+        digitalWrite(x, HIGH);        
+      }
+    }
+    if (pinControl[x] == 4) {
+      pinMode(x, OUTPUT); // Analog Outputs
+    }
+  }
+
+// Start the DHT-22
+  dht1.begin(); 
+  /*for (int x = 0; x < NUM_DHTS; x++) {
+    dhts[x].begin();
+  }*/
+  
+// Start the DS18B20
+  wp_sensors.begin();
+  
+// Start the flow sensor  
+  pinMode(FLOW_SENSORPIN, INPUT);
+  flowrate.attach(FLOW_SENSORPIN);
+  flowrate.interval(5);
+
+}
+
+String getPinArray() {
+  // Returns all pin configuration information
+  String response = "";
+  for (int i = 0; i < NUM_DIGITAL+NUM_ANALOG; i++) {
+    if (i <= (NUM_DIGITAL-1)) {
+      response = response + String(i) + String(pinControl[i]);
+    }
+    else {
+      response = response + "A" + String(i - NUM_DIGITAL) + String(pinControl[i]);
+    }
+  }
+  return response;
+}
+
+float readHumidity(int iDevice) {
+  // readHumidity  - Uses the DHT Library to read the current humidity
+  float returnValue;
+  float h;
+  //h = dhts[iDevice].readHumidity();
+  h = dht1.readHumidity();
+
+  if (isnan(h)) {
+    returnValue = -1;
+  }
+  else {
+    returnValue = h;
+  }
+  return returnValue;
+}
+
+float readTemperatured(int iDevice) {
+  // readTemperature  - Uses the DHT Library to read the current temperature
+  float returnValue;
+  float h;
+  //h = dhts[iDevice].readTemperature();
+  h = dht1.readTemperature();
+
+  if (isnan(h)) {
+    returnValue = -1;
+  }
+  else {
+    returnValue = h;
+    if (metric == false) {
+      returnValue = (returnValue * 9.0)/ 5.0 + 32.0; // Convert Celcius to Fahrenheit 
+    }    
+  }
+  return returnValue;
+}
+
+float read1WireTemperature(int iDevice) {
+  // readWaterTemperature  - Uses the Dallas Temperature library to read the waterproof temp sensor
+  float returnValue;
+  wp_sensors.requestTemperatures();
+  returnValue = wp_sensors.getTempCByIndex(0);
+  
+  if (isnan(returnValue)) {
+    returnValue = -1;
+  }
+  else
+  {  
+    if (metric == false) {
+      returnValue = (returnValue * 9.0)/ 5.0 + 32.0; // Convert Celcius to Fahrenheit 
+    }
+  }
+  return returnValue;
+}
+
+float readpH(int iDevice) {
+  // readpH - Reads pH from an analog pH sensor (Robot Mesh SKU: SEN0161, Module version 1.0)
+  unsigned long int avgValue;  //Store the average value of the sensor feedback
+  float b;
+  int buf[10], temp;
+
+  for (int i = 0; i < 10; i++) //Get 10 sample value from the sensor for smooth the value
+  {
+    buf[i] = analogRead(iDevice);
+    delay(10);
+  }
+  for (int i = 0; i < 9; i++) //sort the analog from small to large
+  {
+    for (int j = i + 1; j < 10; j++)
+    {
+      if (buf[i] > buf[j])
+      {
+        temp = buf[i];
+        buf[i] = buf[j];
+        buf[j] = temp;
+      }
+    }
+  }
+  avgValue = 0;
+  for (int i = 2; i < 8; i++)               //take the average value of 6 center sample
+    avgValue += buf[i];
+  float phValue = (float)avgValue * 5.0 / 1024 / 6; //convert the analog into millivolt
+  phValue = 3.5 * phValue;                  //convert the millivolt into pH value
+  return phValue;
+}
+ 
+float readTDS(int iDevice) {
+  // readTDS - Reads pH from an analog TDS sensor
+  unsigned long int avgValue;  //Store the average value of the sensor feedback
+  float b;
+  int buf[10], temp;
+
+  for (int i = 0; i < 10; i++) //Get 10 sample value from the sensor for smooth the value
+  {
+    buf[i] = analogRead(iDevice);
+    delay(10);
+  }
+  for (int i = 0; i < 9; i++) //sort the analog from small to large
+  {
+    for (int j = i + 1; j < 10; j++)
+    {
+      if (buf[i] > buf[j])
+      {
+        temp = buf[i];
+        buf[i] = buf[j];
+        buf[j] = temp;
+      }
+    }
+  }
+  avgValue = 0;
+  for (int i = 2; i < 8; i++)               //take the average value of 6 center sample
+    avgValue += buf[i];
+  float TDSValue = (float)avgValue * 5.0 / 1024 / 6; //convert the analog into millivolt
+
+  //TODO: Need temperature compensation for TDS
+  TDSValue = 1.0 * TDSValue;                  //convert the millivolt into TDS value
+  
+  return TDSValue;
+}
+
+//  Type                Ambient light (lux)  Photocell resistance (Ω)
+//
+//  Dim hallway         0.1 lux               600KΩ
+//  Moonlit night       1 lux                 70 KΩ
+//  Dark room           10 lux                10 KΩ
+//  Dark overcast day   Bright room 100 lux   1.5 KΩ
+//  Overcast day        1000 lux              300 Ω
+
+float readLightSensorTemp(int iDevice) {
+  // Simple code to read a Light value from a CDS sensor, with 10k to ground
+  float Lux;
+  int RawADC = analogRead(iDevice);
+//TODO 
+  Lux = (float)RawADC; // Need to do some processing to get lux from CDS reading
+
+  return Lux;
+}
+
+
+
+float readFlow(int iDevice) {
+  // readWaterFlowRAte  - Uses an input pulse that creates an average flow rate
+  //                      The averaging is done in software and stores a 30second rolling count
+  return (float)WaterFlowRate;
+}
+

--- a/src/dumb_module/arduino/hapinode/hapinode.ino
+++ b/src/dumb_module/arduino/hapinode/hapinode.ino
@@ -1,0 +1,387 @@
+#include <Arduino.h>
+
+/*
+#*********************************************************************
+#Copyright 2016 Maya Culpa, LLC
+#
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#*********************************************************************
+
+HAPI Remote Terminal Unit Firmware Code v3.0.0
+Authors: Tyler Reed, Mark Miller
+ESP Modification: John Archbold
+
+Sketch Date: May 2nd 2017
+Sketch Version: v3.0.0
+Implement of MQTT-based HAPInode (HN) for use in Monitoring and Control
+Implements mDNS discovery of MQTT broker
+Implements definitions for
+  ESP-NodeMCU
+  ESP8266
+  WROOM32
+Communications Protocol
+  WiFi
+Communications Method
+  MQTT        Listens for messages on Port 1883
+*/
+
+
+//**** Begin Board Configuration Section ****
+
+// Board Type
+// ==========
+//**ESP Based
+// Board Type
+#define HN_ESP8266
+//#define HN_ESP32
+
+// Connection Type
+// ===============
+#define HN_WiFi
+//#define HN_ENET          // Define for Ethernet shield
+
+// Protocol Type
+// =============
+#define HN_MQTT
+
+//**** End Board Configuration Section ****
+
+#include <DHT.h>
+#include <SPI.h>
+#ifdef HN_WiFi
+#include <ESP8266WiFi.h>
+#include <ESP8266mDNS.h>
+#endif
+#ifdef HN_ENET
+#include <Ethernet.h>
+#include <EthernetBonjour.h>
+#endif
+#include <PubSubClient.h> // Allows us to connect to, and publish to the MQTT brokerinclude <stdlib.h>
+#include <ArduinoJson.h>  // JSON library for MQTT strings
+
+#include <math.h>
+#include <EEPROM.h>
+#include <OneWire.h>
+#include <DallasTemperature.h>
+#include <Bounce2.h> // Used for "debouncing" inputs
+
+// =====================================================================
+// Make sure to update these files for your own WiFi and/or MQTT Broker!
+// =====================================================================
+#include "nodewifi.h"       // WiFi and MQTT
+#include "nodeboard.h"      // Node pin allocations
+
+//**** Begin Main Variable Definition Section ****
+String HAPI_FW_VERSION = "v3.0";    // The version of the firmware the HN is running
+#ifdef HN_ESP8266
+String HN_base = "HN3";             // Prefix for mac address
+#endif
+#ifdef HN_ESP32
+String HN_base = "HN4";             // Prefix for mac address
+#endif
+
+String HN_id = "HNx";              // HN address
+String HN_status = "Online";
+
+boolean idle_mode = false;         // a boolean representing the idle mode of the HN
+boolean metric = true;             // should values be returned in metric or US customary units
+String inputString = "";           // A string to hold incoming data
+String inputCommand = "";          // A string to hold the command
+String inputPort = "";             // A string to hold the port number of the command
+String inputControl = "";          // A string to hold the requested action of the command
+String inputTimer = "0";           // A string to hold the length of time to activate a control
+boolean stringComplete = false;    // A boolean indicating when received string is complete (a \n was received)
+//**** End Main Variable Definition Section ****
+
+//**** Begin Communications Section ****
+// the media access control (ethernet hardware) address for the shield
+// Need to manually change this for USB, Ethernet
+byte mac[] = { 0x55, 0x55, 0x55, 0x55, 0x55, 0x55 };
+char mac_str[16] = "555555555555";
+char hostString[32] = {0};              // for mDNS Hostname
+
+#ifdef HN_ENET
+EthernetClient HNClient;
+#endif
+
+#ifdef HN_WiFi
+const char* ssid = HAPI_SSID;
+const char* password = HAPI_PWD;
+int WiFiStatus = 0;
+WiFiClient HNClient;
+#endif
+//**** End Communications Section ****
+
+//**** Begin MQTT Section ****
+const char* clientID = "HAPInode";
+const char* mqtt_topic_status = "STATUS/QUERY";         // General Status topic
+const char* mqtt_topic_asset = "ASSET/QUERY";           // Genral Asset topic
+char mqtt_topic_command[256] = "COMMAND/";              // Command topic for this HN
+const char* mqtt_topic_exception = "EXCEPTION/";        // General Exception topic
+
+StaticJsonBuffer<128> hn_topic_exception;               // Exception data for this HN
+char MQTTOutput[256];                                   // String storage for the JSON data
+char MQTTInput[256];                                    // String storage for the JSON data
+boolean mqtt_broker_connected = false;
+
+// Callback function header
+void MQTTcallback(char* topic, byte* payload, unsigned int length);
+PubSubClient MQTTClient(HNClient);                          // 1883 is the listener port for the Broker
+
+// Prepare JSON string objects
+
+JsonObject& exception_topic = hn_topic_exception.createObject();
+//**** End MQTT Section ****
+
+//**** Begin Sensors Section ****
+// Definitions related to sensor operations
+
+// Initialise the Pushbutton Bouncer object
+const int ledPin = 2; // This code uses the built-in led for visual feedback that the button has been pressed
+const int buttonPin = 13; // Connect your button to pin #gpio13
+int ledflash = 0;
+Bounce bouncer = Bounce();
+
+// Use bouncer object to measure flow rate
+const int FLOW_SENSORPIN = 13; // Input pin for a flow sensor device
+Bounce flowrate = Bounce();
+int WaterFlowRate = 0;
+
+#define SENSORID_D_PIN 0
+#define SENSORID_A_PIN 1
+
+//LIGHT Devices
+#define LIGHTSENSOR_PIN 2
+
+//oneWire Devices
+OneWire oneWire(ONE_WIRE_BUS);
+DallasTemperature wp_sensors(&oneWire);
+
+//Define DHT devices and allocate resources
+#define NUM_DHTS 1        //total number of DHTs on this device
+DHT dht1(DHTPIN, DHT22);  //For each DHT, create a new variable given the pin and Type
+DHT dhts[1] = {dht1};     //add the DHT device to the array of DHTs
+
+//Custom functions are special functions for reading sensors or controlling devices. They are
+//used when setting or a reading a pin isn't enough, as in the instance of library calls.
+typedef float (* GenericFP)(int); //generic pointer to a function that takes an int and returns a float
+struct FuncDef {   //define a structure to associate a Name to generic function pointer.
+  String fName;
+  String fType;
+  String fUnit;
+  int fPin;
+  GenericFP fPtr;
+};
+
+#define SENSORID_FN 2
+//The number of custom functions supported on this HN
+#define CUSTOM_FUNCTIONS 7
+//Create a FuncDef for each custom function
+//Format: abbreviation, context, pin, function
+FuncDef func1 = {"tmp", "dht", "C", -1, &readTemperatured};
+FuncDef func2 = {"hum", "dht", "%", -1, &readHumidity};
+FuncDef func3 = {"lux", "light", "lux", LIGHTSENSOR_PIN, &readLightSensorTemp};
+FuncDef func4 = {"tmp1", "DS18B20", "C", ONE_WIRE_BUS, &read1WireTemperature};
+FuncDef func5 = {"ph", "pH Sensor", "pH", PH_SENSORPIN, &readpH};
+FuncDef func6 = {"tds", "TDS Sensor", "ppm", TDS_SENSORPIN, &readTDS};
+FuncDef func7 = {"flow", "Flow Rate Sensor", "lpm", FLOW_SENSORPIN, &readFlow};
+FuncDef HapiFunctions[CUSTOM_FUNCTIONS] = {func1, func2, func3, func4, func5, func6, func7};
+
+//**** End Sensors Section ****
+
+void b2c(byte* bptr, char* cptr, int len) {
+  int i;
+  char c;
+  for (i=0; i<len; i++) {
+    c = (bptr[i] >> 4) & 0x0f;
+    c += '0';
+    if (c > '9') c += ('A' - '9' - 1);
+    *cptr++ = c;
+//    Serial.print(c, HEX);
+    c = bptr[i] & 0x0f;
+    c += '0';
+    if (c > '9') c += ('A' - '9' - 1);
+    *cptr++ = c;
+//    Serial.print(c, HEX);
+  }
+  *cptr++ = '\0';
+//  Serial.println("");
+}
+
+int freeRam (){
+#ifdef HN_ESP8266
+// Gets free ram on the ESP8266
+  return ESP.getFreeHeap();
+#else
+// Gets free ram on the Arduino
+  extern int __heap_start, *__brkval;
+  int v;
+  return (int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval);
+#endif
+}
+
+void setup() {
+// Switch the on-board LED off to start with
+  pinMode(ledPin, OUTPUT);
+  digitalWrite(ledPin, HIGH);
+
+//TESTING
+// Setup pushbutton Bouncer object
+  pinMode(buttonPin, INPUT);
+  bouncer.attach(buttonPin);
+  bouncer.interval(5);
+// TESTING
+
+  setupSensors();             // Initialize I/O and start devices
+  inputString.reserve(200);   // reserve 200 bytes for the inputString
+  Serial.begin(115200);       // Debug port
+
+#ifdef HN_ENET
+  Serial.println("Initializing network....");
+  if (Ethernet.begin(mac) == 0) {
+    Serial.println("Failed to obtain IP address  ...");
+  } else
+  {
+    Serial.print("IP address: ");
+    Serial.println(Ethernet.localIP());
+  }
+
+  //TODO
+  // Bonjour support
+#endif
+
+#ifdef HN_WiFi
+  Serial.println("Initializing WiFi network....");
+  WiFiStatus = WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  WiFi.macAddress(mac);
+    Serial.print("IP  address: ");
+    Serial.println(WiFi.localIP());
+
+// mDNS support
+// ===============
+//convert mac to ASCII value for unique station ID
+  b2c(&mac[3], &mac_str[0], 3);
+  HN_id = HN_base + String(mac_str);
+  HN_id.toCharArray(hostString,(HN_id.length()+1));
+  Serial.print("HN_id:      ");
+  Serial.println(HN_id);
+  Serial.print("hostString: ");
+  Serial.println(hostString);
+
+ if (!MDNS.begin(hostString)) {
+    Serial.println("Error setting up MDNS responder!");
+  }
+  Serial.print("Hostname: ");
+  Serial.print(hostString);
+  Serial.println(" mDNS responder started");
+
+  Serial.println("Sending mDNS query");
+  int n = MDNS.queryService("workstation", "tcp"); // Send out query for workstation tcp services
+  Serial.println("mDNS query done");
+  if (n == 0) {
+    Serial.println("no services found");
+  }
+  else {
+    Serial.print(n);
+    Serial.println(" service(s) found");
+    for (int i = 0; i < n; ++i) {
+      // Print details for each service found
+      Serial.print(i + 1);
+      Serial.print(": ");
+      Serial.print(MDNS.hostname(i));
+      Serial.print(" (");
+      Serial.print(MDNS.IP(i));
+      Serial.print(":");
+      Serial.print(MDNS.port(i));
+      Serial.println(")");
+    }
+  }
+  Serial.println();
+#endif
+
+  MQTTClient.setServer(MQTT_broker_address, 1883);
+  MQTTClient.setCallback(MQTTcallback);
+
+  exception_topic["AssetId"] = HN_id;
+
+  // Wait until connected to MQTT Broker
+  // client.connect returns a boolean value
+  mqtt_broker_connected = false;
+  Serial.println("Connecting to MQTT broker ...");
+  do {
+    if (sendMQTTStatus()) {
+      mqtt_broker_connected = true;
+    }
+  } while (mqtt_broker_connected == false);
+
+  // Subscribe to the TOPICs
+/*  while (!(MQTTClient.subscribe("STATUS/QUERY"))) {
+    Serial.println(" .. subscribing to STATUS/QUERY");
+    delay(100);
+  }
+  while (!(MQTTClient.subscribe("ASSET/QUERY"))) {
+    Serial.println(" .. subscribing to ASSET/QUERY");
+    delay(100);
+  }
+*/  while (!(MQTTClient.subscribe("COMMAND/"))) {
+    Serial.println(" .. subscribing to COMMAND/");
+    delay(100);
+  }
+  while (!(MQTTClient.subscribe("EXCEPTION/"))) {
+    Serial.println(" .. subscribing to EXCEPTION/");
+    delay(100);
+  }
+  
+  Serial.println("Setup Complete. Listening for topics ..");
+}
+
+void loop() {
+
+  // Wait for a new event, publish topic
+  // Fake this event with a push-button
+  // Update button state
+  // This needs to be called so that the Bouncer object can check if the button has been pressed
+  bouncer.update();
+  if (bouncer.rose()) {
+    // Turn light on when button is pressed down
+    // (i.e. if the state of the button rose from 0 to 1 (not pressed to pressed))
+    digitalWrite(ledPin, LOW);
+    Serial.println("Button pushed");
+    sendMQTTStatus();
+    sendAllMQTTAssets();
+  }
+  else if (bouncer.fell()) {
+    // Turn light off when button is released
+    // i.e. if state goes from high (1) to low (0) (pressed to not pressed)
+    digitalWrite(ledPin, HIGH);
+  }
+  flashled();
+  MQTTClient.loop();
+  delay(100);
+}
+
+void flashled(void) {
+  if (ledflash == 0) {
+    digitalWrite(ledPin, LOW);
+  }
+  else if (ledflash == 1600) {
+    digitalWrite(ledPin, HIGH);
+  }
+  ledflash += 1;
+  if (ledflash > 64000) ledflash = 0;
+}

--- a/src/dumb_module/arduino/hapinode/nodeboard.h
+++ b/src/dumb_module/arduino/hapinode/nodeboard.h
@@ -1,0 +1,118 @@
+/*
+#*********************************************************************
+#Copyright 2016 Maya Culpa, LLC
+#
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#*********************************************************************
+
+HAPI Remote Terminal Unit Firmware Code v3.0.0
+Authors: Tyler Reed, Mark Miller
+ESP Modification: John Archbold
+
+Sketch Date: May 2nd 2017
+Sketch Version: v3.0.0
+Implement of MQTT-based HAPInode (HN) for use in Monitoring and Control
+Implements mDNS discovery of MQTT broker
+Implements definitions for 
+  ESP-NodeMCU
+  ESP8266
+  WROOM32
+Communications Protocol
+  WiFi
+Communications Method
+  MQTT        Listens for messages on Port 1883
+*/
+
+#ifndef HAPIBOARD_H
+#define HAPIBOARD_H
+
+#ifdef HN_ESP32
+#define NUM_DIGITAL 54    // Number of digital I/O pins
+#define NUM_ANALOG  16    // Number of analog I/O pins
+#define PIN_MAP_SIZE NUM_DIGITAL*2   // Array size for default digital state data
+                                     // 2 bytes per digital I/O pin, 1st byte = State, 2nd byte = Value
+// Default pin allocation
+#define ONE_WIRE_BUS 8   // Reserved pin for 1-Wire bus
+#define PH_SENSORPIN A1  // Reserved pin for pH probe
+#define DHTTYPE DHT22    // Sets DHT type
+#define DHTPIN 12        // Reserved pin for DHT-22 sensor
+
+// Default pin modes
+// 0 not used or reserved;  1 digital input; 2 digital input_pullup; 3 digital output; 4 analog output; 5 analog input;
+// Analog input pins are assumed to be used as analog input pins
+int pinControl[NUM_DIGITAL+NUM_ANALOG] = {
+                                  // DIGITAL
+  0, 0, 3, 0, 3, 3, 0, 0, 0, 0,   //  0 -  9
+  0, 0, 3, 3, 3, 3, 0, 0, 3, 3,   // 10 - 19
+  0, 3, 3, 3, 0, 3, 3, 3, 0, 0,   // 20 - 29
+  0, 0, 3, 3, 3, 3, 0, 0, 0, 0,   // 30 - 39
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   // 40 - 49
+  0, 0, 0, 0,                     // 50 - 53
+                                  // ANALOG
+  5, 5, 5, 5, 5, 5, 5, 5, 5, 5,   // 54 - 63
+  5, 5, 0, 0, 0, 0                // 64 - 69
+};
+
+// Default pin states
+// Defaults determine the value of output pins with the HN initializes
+// 0 = LOW, 1 = HIGH
+int pinDefaults[NUM_DIGITAL+NUM_ANALOG] = {
+                                  // DIGITAL
+  0, 0, 1, 1, 0, 1, 1, 1, 1, 1,   //  0 -  9
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   // 10 - 19
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   // 20 - 29
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   // 30 - 39
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   // 40 - 49
+  0, 0, 0, 0,                     // 50 - 53
+                                  // ANALOG
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   // 54 - 63
+  0, 0, 0, 0, 0, 0                // 64 - 69
+};
+#endif
+
+#ifdef HN_ESP8266
+#define NUM_DIGITAL 17    // Number of digital I/O pins
+#define NUM_ANALOG  1     // Number of analog I/O pins
+#define PIN_MAP_SIZE NUM_DIGITAL*2   // Array size for default state data
+                                     // 2 bytes per digital I/O pin, 1st byte = State, 2nd byte = Value
+
+// Default pin allocation
+#define ONE_WIRE_BUS 13   // Reserved pin for 1-Wire bus
+#define PH_SENSORPIN 14   // Reserved pin for pH probe
+#define TDS_SENSORPIN 15  // Reserved pin for TDS probe
+#define DHTTYPE DHT22     // Sets DHT type
+#define DHTPIN 12         // Reserved pin for DHT-22 sensor
+
+// Default pin modes
+// 0 not used or reserved;  1 digital input; 2 digital input_pullup; 3 digital output; 4 analog output; 5 analog input;
+// Analog input pins are assumed to be used as analog input pins
+int pinControl[NUM_DIGITAL+NUM_ANALOG] = {
+  3, 3, 3, 1, 3, 3, 0, 0,   //  0 -  7  // Digital i/o
+  0, 0, 0, 0, 3, 3, 3, 3,   //  8 - 15
+  3,                        // 16
+  5                         // A0       //Analog Input
+};
+
+// Default pin states
+// Defaults determine the value of output pins with the HN initializes
+// 0 = LOW, 1 = HIGH
+int pinDefaults[NUM_DIGITAL+NUM_ANALOG] = {
+  1, 1, 1, 1, 1, 1, 0, 0,   //  0 -  7  // Digital i/o
+  0, 0, 0, 0, 1, 1, 1, 1,   //  8 - 15
+  1,                        // 16
+  5                         // A0       //Analog Input
+};
+#endif
+
+#endif //HAPIBOARD_H

--- a/src/dumb_module/arduino/hapinode/nodewifi.h
+++ b/src/dumb_module/arduino/hapinode/nodewifi.h
@@ -1,0 +1,53 @@
+/*
+#*********************************************************************
+#Copyright 2016 Maya Culpa, LLC
+#
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#*********************************************************************
+
+HAPI Remote Terminal Unit Firmware Code v3.0.0
+Authors: Tyler Reed, Mark Miller
+ESP Modification: John Archbold
+
+Sketch Date: May 2nd 2017
+Sketch Version: v3.0.0
+Implement of MQTT-based HAPInode (HN) for use in Monitoring and Control
+Implements mDNS discovery of MQTT broker
+Implements definitions for 
+  ESP-NodeMCU
+  ESP8266
+  WROOM32
+Communications Protocol
+  WiFi
+Communications Method
+  MQTT        Listens for messages on Port 1883
+*/
+
+#ifndef HAPIWiFi_H
+#define HAPIWiFi_H
+
+// ==============================================================
+// Make sure to update this for your own WiFi and/or MQTT Broker!
+// ==============================================================
+
+#define MQTT_broker_address "mqttbroker"    // IP address of mqtt broker
+#define MQTT_broker_username "mqttuser"      // Required if broker security is enabled
+#define MQTT_broker_password "mqttpass"
+
+#ifdef HN_WiFi
+#define HAPI_SSID "HAPInet"
+#define HAPI_PWD  "HAPIconnect"
+#endif
+
+#endif //HAPIWiFi_H


### PR DESCRIPTION
This code has only been tested on the NodeMCu - 12e version.
It provides support for MQTT.
The HAPInode creates an AssetId from its mac address and the prefix HN3.
e.g. AssetId:HN3D50344
It uses this address as its hostname which it publishes via mDNS.
A HAPImodule can discover this name using arp-scan.
The HAPInode subscribes to the COMMAND/ and EXCEPTION/ topics on the mqttbroker.local host.
It responds to any message on the COMMAND/ topic that has its AssetId key in its payload.
Currently it implements two commands, status, assets.
These commands are in the payload of the COMMAND/ topic using the Cmnd key.
e.g. status
COMMAND/ topic - {"AssetId":"HN3D50344","Cmnd":"status"}
STATUS/QUERY response -{"AssetId":"HN3D50344","FW":"v3.0","DIO":"17","AIO":"1","Free SRAM":"42096k"}
e.g. assets
COMMAND/ topic - {"AssetId":"HN3D50344","Cmnd":"assets"}
{"AssetId":"HN3D50344","SId":"0.0","name":"DIO","unit":"","data":"1"}
{"AssetId":"HN3D50344","SId":"0.1","name":"DIO","unit":"