### PR TITLE
src/smart_module/rtc_interface.py: Fixed subtle bug

### DIFF
--- a/src/smart_module/rtc_interface.py
+++ b/src/smart_module/rtc_interface.py
@@ -135,10 +135,10 @@ class RTCInterface(object):
             return mock_value
 
         try:
-            bytes_ = (
+            bytes_ = [
                 self.ds3231.read_AT24C32_byte(address + i)
                 for i in range(n)
-            )
+            ]
         except Exception, excpt:
             self.logger.exception("Error reading %s from EEPROM. %s", name, excpt)
 


### PR DESCRIPTION
Generator expressions are fantastic. In this situation, the
delayed evaluation could happen outside the try block that the
generator expression is in. So the generator expression was
changed to a list comprehension to force immediate evaluation so
that any errors are caught.