### PR TITLE
Support for local NTP, uses COMMAND/ topic

### DIFF
--- a/src/dumb_module/arduino/hapinode/hapi_ntp.ino
+++ b/src/dumb_module/arduino/hapinode/hapi_ntp.ino
@@ -1,0 +1,116 @@
+/*
+#*********************************************************************
+#Copyright 2016 Maya Culpa, LLC
+#
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#*********************************************************************
+
+HAPI Remote Terminal Unit Firmware Code v3.0.0
+Authors: Tyler Reed, Mark Miller
+ESP Modification: John Archbold
+
+Sketch Date: May 2nd 2017
+Sketch Version: v3.0.0
+Implement of MQTT-based HAPInode (HN) for use in Monitoring and Control
+Implements mDNS discovery of MQTT broker
+Implements definitions for
+  ESP-NodeMCU
+  ESP8266
+  WROOM32
+Communications Protocol
+  WiFi
+Communications Method
+  MQTT        Listens for messages on Port 1883
+*/
+
+boolean getNTPTime(void) {
+  sendNTPpacket(timeServerIP); // send an NTP packet to a time server
+  // wait to see if a reply is available
+  delay(1000);
+  
+  int cb = udp.parsePacket();
+  if (!cb) {
+    Serial.println("no packet yet");
+  }
+  else {
+//    Serial.print("packet received, length=");
+//    Serial.println(cb);
+    // We've received a packet, read the data from it
+    udp.read(packetBuffer, NTP_PACKET_SIZE); // read the packet into the buffer
+
+    //the timestamp starts at byte 40 of the received packet and is four bytes,
+    // or two words, long. First, esxtract the two words:
+
+    unsigned long highWord = word(packetBuffer[40], packetBuffer[41]);
+    unsigned long lowWord = word(packetBuffer[42], packetBuffer[43]);
+    // combine the four bytes (two words) into a long integer
+    // this is NTP time (seconds since Jan 1 1900):
+    unsigned long secsSince1900 = highWord << 16 | lowWord;
+//    Serial.print("Seconds since Jan 1 1900 = " );
+//    Serial.println(secsSince1900);
+
+    // now convert NTP time into everyday time:
+    Serial.print("Unix time = ");
+    // Unix time starts on Jan 1 1970. In seconds, that's 2208988800:
+    const unsigned long seventyYears = 2208988800UL;
+    // subtract seventy years:
+    epoch = secsSince1900 - seventyYears;
+    // print Unix time:
+    Serial.println(epoch);
+
+/*
+    // print the hour, minute and second:
+    Serial.print("The UTC time is ");       // UTC is the time at Greenwich Meridian (GMT)
+    Serial.print((epoch  % 86400L) / 3600); // print the hour (86400 equals secs per day)
+    Serial.print(':');
+    if ( ((epoch % 3600) / 60) < 10 ) {
+      // In the first 10 minutes of each hour, we'll want a leading '0'
+      Serial.print('0');
+    }
+    Serial.print((epoch  % 3600) / 60); // print the minute (3600 equals secs per minute)
+    Serial.print(':');
+    if ( (epoch % 60) < 10 ) {
+      // In the first 10 seconds of each minute, we'll want a leading '0'
+      Serial.print('0');
+    }
+    Serial.println(epoch % 60); // print the second
+    */
+  }
+}
+
+// send an NTP request to the time server at the given address
+unsigned long sendNTPpacket(IPAddress& address)
+{
+  Serial.println("sending NTP packet...");
+  // set all bytes in the buffer to 0
+  memset(packetBuffer, 0, NTP_PACKET_SIZE);
+  // Initialize values needed to form NTP request
+  // (see URL above for details on the packets)
+  packetBuffer[0] = 0b11100011;   // LI, Version, Mode
+  packetBuffer[1] = 0;     // Stratum, or type of clock
+  packetBuffer[2] = 6;     // Polling Interval
+  packetBuffer[3] = 0xEC;  // Peer Clock Precision
+  // 8 bytes of zero for Root Delay & Root Dispersion
+  packetBuffer[12]  = 49;
+  packetBuffer[13]  = 0x4E;
+  packetBuffer[14]  = 49;
+  packetBuffer[15]  = 52;
+
+  // all NTP fields have been given values, now
+  // you can send a packet requesting a timestamp:
+  udp.beginPacket(address, 123); //NTP requests are to port 123
+  udp.write(packetBuffer, NTP_PACKET_SIZE);
+  udp.endPacket();
+}
+

--- a/src/dumb_module/arduino/hapinode/hapi_sensors.ino
+++ b/src/dumb_module/arduino/hapinode/hapi_sensors.ino
@@ -1,5 +1,3 @@
-#include <Arduino.h>
-
 /*
 #*********************************************************************
 #Copyright 2016 Maya Culpa, LLC
@@ -73,7 +71,6 @@ void setupSensors(void){
   pinMode(FLOW_SENSORPIN, INPUT);
   flowrate.attach(FLOW_SENSORPIN);
   flowrate.interval(5);
-
 }
 
 String getPinArray() {
@@ -103,7 +100,8 @@ float readHumidity(int iDevice) {
   else {
     returnValue = h;
   }
-  return returnValue;
+  Serial.print("DHT Humidity: ");
+  Serial.println(returnValue);  return returnValue;
 }
 
 float readTemperatured(int iDevice) {
@@ -122,6 +120,8 @@ float readTemperatured(int iDevice) {
       returnValue = (returnValue * 9.0)/ 5.0 + 32.0; // Convert Celsius to Fahrenheit
     }
   }
+  Serial.print("DHT Temperature: ");
+  Serial.println(returnValue);
   return returnValue;
 }
 
@@ -137,9 +137,11 @@ float read1WireTemperature(int iDevice) {
   else
   {
     if (metric == false) {
-      returnValue = (returnValue * 9.0)/ 5.0 + 32.0; // Convert Celsius to Fahrenheit
+      returnValue = (returnValue * 9.0)/ 5.0 + 32.0; // Convert Celsius to Fahrenheit 
     }
   }
+  Serial.print("18B20 Temperature: ");
+  Serial.println(returnValue);
   return returnValue;
 }
 
@@ -171,6 +173,8 @@ float readpH(int iDevice) {
     avgValue += buf[i];
   float phValue = (float)avgValue * 5.0 / 1024 / 6; //convert the analog into millivolt
   phValue = 3.5 * phValue;                  //convert the millivolt into pH value
+  Serial.print("pH: ");
+  Serial.println(phValue);
   return phValue;
 }
 
@@ -204,7 +208,8 @@ float readTDS(int iDevice) {
 
   //TODO: Need temperature compensation for TDS
   TDSValue = 1.0 * TDSValue;                  //convert the millivolt into TDS value
-
+  Serial.print("TDS: ");
+  Serial.println(TDSValue); 
   return TDSValue;
 }
 
@@ -225,8 +230,6 @@ float readLightSensorTemp(int iDevice) {
 
   return Lux;
 }
-
-
 
 float readFlow(int iDevice) {
   // readWaterFlowRAte  - Uses an input pulse that creates an average flow rate

--- a/src/dumb_module/arduino/hapinode/nodeboard.h
+++ b/src/dumb_module/arduino/hapinode/nodeboard.h
@@ -37,16 +37,57 @@ Communications Method
 #ifndef HAPIBOARD_H
 #define HAPIBOARD_H
 
+#ifdef HN_ESP8266
+#define NUM_DIGITAL 17    // Number of digital I/O pins
+#define NUM_ANALOG  1     // Number of analog I/O pins
+#define PIN_MAP_SIZE NUM_DIGITAL*2   // Array size for default state data
+                                     // 2 bytes per digital I/O pin, 1st byte = State, 2nd byte = Value
+
+// Default pin allocation
+#define PUMP1_PIN 1       // Reserved pin for a pump control
+#define PUMP2_PIN 3       // Reserved pin for a pump control
+#define LIGHT_SENSORPIN 2 // Reserved pin for a Light sensor
+#define FLOW_SENSORPIN 4  // Reserved pin for a flow sensor
+#define DHT_SENSORPIN 12  // Reserved pin for DHT-22 sensor
+#define ONE_WIRE_BUS 13   // Reserved pin for 1-Wire bus
+#define PH_SENSORPIN 14   // Reserved pin for pH probe
+#define TDS_SENSORPIN 15  // Reserved pin for TDS probe
+
+// Default pin modes
+// 0 not used or reserved;  1 digital input; 2 digital input_pullup; 3 digital output; 4 analog output; 5 analog input;
+// Analog input pins are assumed to be used as analog input pins
+int pinControl[NUM_DIGITAL+NUM_ANALOG] = {
+  3, 3, 3, 1, 3, 3, 0, 0,   //  0 -  7  // Digital i/o
+  0, 0, 0, 0, 3, 3, 3, 3,   //  8 - 15
+  3,                        // 16
+  5                         // A0       //Analog Input
+};
+
+// Default pin states
+// Defaults determine the value of output pins with the HN initializes
+// 0 = LOW, 1 = HIGH
+int pinDefaults[NUM_DIGITAL+NUM_ANALOG] = {
+  1, 1, 1, 1, 1, 1, 0, 0,   //  0 -  7  // Digital i/o
+  0, 0, 0, 0, 1, 1, 1, 1,   //  8 - 15
+  1,                        // 16
+  5                         // A0       //Analog Input
+};
+#endif
+
 #ifdef HN_ESP32
 #define NUM_DIGITAL 54    // Number of digital I/O pins
 #define NUM_ANALOG  16    // Number of analog I/O pins
 #define PIN_MAP_SIZE NUM_DIGITAL*2   // Array size for default digital state data
                                      // 2 bytes per digital I/O pin, 1st byte = State, 2nd byte = Value
 // Default pin allocation
-#define ONE_WIRE_BUS 8   // Reserved pin for 1-Wire bus
-#define PH_SENSORPIN A1  // Reserved pin for pH probe
-#define DHTTYPE DHT22    // Sets DHT type
-#define DHTPIN 12        // Reserved pin for DHT-22 sensor
+#define PUMP1_PIN 1       // Reserved pin for a pump control
+#define PUMP2_PIN 3       // Reserved pin for a pump control
+#define LIGHT_SENSORPIN 2 // Reserved pin for a Light sensor
+#define FLOW_SENSORPIN 4  // Reserved pin for a flow sensor
+#define DHT_SENSORPIN 12  // Reserved pin for DHT-22 sensor
+#define ONE_WIRE_BUS 13   // Reserved pin for 1-Wire bus
+#define PH_SENSORPIN 14   // Reserved pin for pH probe
+#define TDS_SENSORPIN 15  // Reserved pin for TDS probe
 
 // Default pin modes
 // 0 not used or reserved;  1 digital input; 2 digital input_pullup; 3 digital output; 4 analog output; 5 analog input;
@@ -78,40 +119,6 @@ int pinDefaults[NUM_DIGITAL+NUM_ANALOG] = {
                                   // ANALOG
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   // 54 - 63
   0, 0, 0, 0, 0, 0                // 64 - 69
-};
-#endif
-
-#ifdef HN_ESP8266
-#define NUM_DIGITAL 17    // Number of digital I/O pins
-#define NUM_ANALOG  1     // Number of analog I/O pins
-#define PIN_MAP_SIZE NUM_DIGITAL*2   // Array size for default state data
-                                     // 2 bytes per digital I/O pin, 1st byte = State, 2nd byte = Value
-
-// Default pin allocation
-#define ONE_WIRE_BUS 13   // Reserved pin for 1-Wire bus
-#define PH_SENSORPIN 14   // Reserved pin for pH probe
-#define TDS_SENSORPIN 15  // Reserved pin for TDS probe
-#define DHTTYPE DHT22     // Sets DHT type
-#define DHTPIN 12         // Reserved pin for DHT-22 sensor
-
-// Default pin modes
-// 0 not used or reserved;  1 digital input; 2 digital input_pullup; 3 digital output; 4 analog output; 5 analog input;
-// Analog input pins are assumed to be used as analog input pins
-int pinControl[NUM_DIGITAL+NUM_ANALOG] = {
-  3, 3, 3, 1, 3, 3, 0, 0,   //  0 -  7  // Digital i/o
-  0, 0, 0, 0, 3, 3, 3, 3,   //  8 - 15
-  3,                        // 16
-  5                         // A0       //Analog Input
-};
-
-// Default pin states
-// Defaults determine the value of output pins with the HN initializes
-// 0 = LOW, 1 = HIGH
-int pinDefaults[NUM_DIGITAL+NUM_ANALOG] = {
-  1, 1, 1, 1, 1, 1, 0, 0,   //  0 -  7  // Digital i/o
-  0, 0, 0, 0, 1, 1, 1, 1,   //  8 - 15
-  1,                        // 16
-  5                         // A0       //Analog Input
 };
 #endif
 

--- a/src/dumb_module/arduino/hapinode/nodewifi.h
+++ b/src/dumb_module/arduino/hapinode/nodewifi.h
@@ -44,6 +44,9 @@ Communications Method
 #define MQTT_broker_address "mqttbroker"    // IP address of mqtt broker
 #define MQTT_broker_username "mqttuser"      // Required if broker security is enabled
 #define MQTT_broker_password "mqttpass"
+#define MQTT_port 1883
+
+#define UDP_port 2390
 
 #ifdef HN_WiFi
 #define HAPI_SSID "HAPInet"


### PR DESCRIPTION
This version supports ntp sync with "mqttbroker.local" running as the time server.
The time is then sync'd on the node and each response is time-stamped with the UTC time.

This version uses the Cmnd key in the COMMAND/ topic in addition to the STATUS/QUERY, ASSET/QUERY  topics.
Responses are published to the STATUS/RESPONSE and ASSET/RESPONSE topics
This can be changed.