### PR TITLE
src/smart_module/smart_module.py: Disable month and year scheduling.

### DIFF
--- a/src/smart_module/smart_module.py
+++ b/src/smart_module/smart_module.py
@@ -509,8 +509,8 @@ class Scheduler(object):
     def prepare_jobs(self, jobs):
         # It still has space for improvements.
         suffixed_names = {
-            'year': 'yearly',
-            'month': 'monthly',
+            # 'year': 'yearly',  # Not supported by schedule library.
+            # 'month': 'monthly',  # Not supported by schedule library.
             'week': 'weekly',
             'day': 'daily',
             'hour': 'hourly',


### PR DESCRIPTION
It seems that the schedule library does not support month and year scheduling.

Maybe it would be good to add month and year to schedule,
but that is outside the scope of this project.