### PR TITLE
Small log.py to handle logs and reverting Jame's change [for now]. See comment...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,105 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
 *.sublime-workspace
 *.swp
 *.db

--- a/src/smart_module/alert.py
+++ b/src/smart_module/alert.py
@@ -23,9 +23,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from __future__ import print_function
-import logging
 import sqlite3
-from utilities import SM_LOGGER, DB_CORE
+import log
+from utilities import DB_CORE
 
 class Alert(object):
     """Hold Alert information fetched from database and check for alerts."""
@@ -36,6 +36,7 @@ class Alert(object):
         self.upper_threshold = 0.0
         self.message = ""
         self.response_type = ""
+        self.logger = log.Log("alert.log")
 
     def __str__(self):
         """Use to pass Alert information in JSON."""
@@ -49,7 +50,7 @@ class Alert(object):
     def update_alert(self):
         """Fetch alert parameters from database."""
         try:
-            logging.getLogger(SM_LOGGER).info("Fetching alert param. from database")
+            self.logger.info("Fetching alert param. from database")
             field_names = '''
                 lower_threshold
                 upper_threshold
@@ -66,11 +67,9 @@ class Alert(object):
             self.upper_threshold = float(self.upper_threshold)
             database.close()
         except Exception, excpt:
-            logging.getLogger(SM_LOGGER).exception("Error fetching alert param. from database: %s",
-                                                   excpt)
+            self.logger.exception("Error fetching alert param. from database: %s." % excpt)
 
     def check_alert(self, current_value):
         """Check for alert."""
         if not self.lower_threshold <= float(current_value) <= self.upper_threshold:
-            print("Alert detected.")
-            print("Value: ", current_value)
+            self.logger.info("ALERT DETECTED.\n  Value: %s." % current_value)

--- a/src/smart_module/asset_wt.py
+++ b/src/smart_module/asset_wt.py
@@ -26,8 +26,7 @@ from __future__ import print_function
 import os
 import glob
 import time
-import logging
-from utilities import SM_LOGGER
+import log
 
 class AssetImpl(object):
     def __init__(self):
@@ -38,9 +37,10 @@ class AssetImpl(object):
             base_dir = '/sys/bus/w1/devices'
             device_dir = glob.glob(os.path.join(base_dir, '28*'))[0]
             self.device_path = os.path.join(device_dir, 'w1_slave')
+            self.log = log.Log("asset.log")
             print('Device file:', self.device_path)
         except Exception, excpt:
-            logging.getLogger(SM_LOGGER).exception("Error initializing sensor interface: %s", excpt)
+            self.log.exception("Error initializing sensor interface: %s." % excpt)
 
     def read_temp_raw(self):
         try:
@@ -50,7 +50,7 @@ class AssetImpl(object):
                     lines = lines + line.decode("utf-8")
             return lines.split("\n")
         except Exception, excpt:
-            logging.getLogger(SM_LOGGER).exception("Error reading raw temperature data: %s", excpt)
+            self.log.exception("Error reading raw temperature data: %s." % excpt)
 
     def read_value(self):
         temp_c = -50
@@ -66,6 +66,6 @@ class AssetImpl(object):
                 temp_c = float(temp_string) / 1000.0
 
         except Exception, excpt:
-            logging.getLogger(SM_LOGGER).exception("Error getting converted sensor data: %s", excpt)
+            self.log.exception("Error getting converted sensor data: %s." % excpt)
 
         return temp_c

--- a/src/smart_module/communicator.py
+++ b/src/smart_module/communicator.py
@@ -24,9 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
 import datetime
-import logging
+import log
 import paho.mqtt.client as mqtt
-from utilities import SM_LOGGER
 
 class Communicator(object):
     def __init__(self, sm):
@@ -45,21 +44,21 @@ class Communicator(object):
         self.is_connected = False
         self.scheduler_found = False
         self.broker_connections = -1
-        self.logger = logging.getLogger(SM_LOGGER)
+        self.logger = log.Log("communicator.log")
         self.logger.info("Communicator initialized")
 
     def connect(self):
         try:
-            self.logger.info("Connecting to %s at %s.", self.broker_name, self.broker_ip)
+            self.logger.info("Connecting to %s at %s." % (self.broker_name, self.broker_ip))
             #self.client.connect(host=self.broker_name, port=1883, keepalive=60)
             self.client.connect(host=self.broker_ip, port=1883, keepalive=60)
         except Exception, excpt:
-            self.logger.exception("Error connecting to broker. %s", excpt)
+            self.logger.exception("Error connecting to broker: %s." % excpt)
 
     def on_disconnect(self, client, userdata, rc):
         # We could implement a reconnect call.
         self.is_connected = False
-        self.logger.info("Disconnected: %s.", mqtt.error_string(rc))
+        self.logger.info("Disconnected: %s." % mqtt.error_string(rc))
 
     # The callback for when the client receives a CONNACK response from the server.
     #@staticmethod
@@ -145,4 +144,4 @@ class Communicator(object):
             if self.client:
                 self.client.publish(topic, message)
         except Exception, excpt:
-            self.logger.info("Error publishing message: %s", excpt)
+            self.logger.info("Error publishing message: %s." % excpt)

--- a/src/smart_module/log.py
+++ b/src/smart_module/log.py
@@ -52,12 +52,12 @@ class Log(object):
         """Append INFORMATION in information to file. Accepts a single string."""
         string = self.build_string("INFO", information)
         with open(self.log_file, "a") as log:
-            log.write(string)
+            log.write(string + "\n")
         print(string)
 
     def exception(self, information):
         """Append EXCEPTION in information to file. Accepts a single string."""
         string = self.build_string("EXCEPTION", information)
         with open(self.log_file, "a") as log:
-            log.write(string)
+            log.write(string + "\n")
         print(string)

--- a/src/smart_module/log.py
+++ b/src/smart_module/log.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+HAPI Smart Module v2.1.2
+Release: April 2017 Beta Milestone
+
+First attempt of implement small log functionality.
+-> Standard option has memory leak when running multithreaded systems.
+--> This is a testing!
+
+This module is really simple and small. It should be improved if sticking to it.
+
+Copyright 2016 Maya Culpa, LLC
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from __future__ import print_function
+import datetime
+
+class Log(object):
+    """Hold information about logging."""
+
+    def __init__(self, log_file):
+        """Initialize object with initial information such as file for writing."""
+        self.log_file = log_file
+        self.mask = "{date} - {name} - {log_type} - {string}"
+
+    def build_string(self, log_type, information):
+        """Build string with mask and return it."""
+        string = self.mask.format(
+            date=datetime.datetime.now(),
+            name=self.log_file,
+            log_type=log_type,
+            string=str(information),
+        )
+        return str(string)
+
+    def info(self, information):
+        """Append INFORMATION in information to file. Accepts a single string."""
+        string = self.build_string("INFO", information)
+        with open(self.log_file, "a") as log:
+            log.write(string)
+        print(string)
+
+    def exception(self, information):
+        """Append EXCEPTION in information to file. Accepts a single string."""
+        string = self.build_string("EXCEPTION", information)
+        with open(self.log_file, "a") as log:
+            log.write(string)
+        print(string)

--- a/src/smart_module/rtc_interface.py
+++ b/src/smart_module/rtc_interface.py
@@ -23,8 +23,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import random
 import datetime
-import logging
 import time
+import log
 
 some_import_failed = False
 try:
@@ -36,8 +36,6 @@ try:
     import RPi.GPIO as GPIO
 except ImportError:
     some_import_failed = True
-
-from utilities import SM_LOGGER
 
 TYPE_ADDRESS = 0
 TYPE_LEN = 2
@@ -58,7 +56,7 @@ class RTCInterface(object):
     def __init__(self):
         self.mock = some_import_failed
 
-        self.logger = logging.getLogger(SM_LOGGER)
+        self.logger = log.Log("rtc.log")
 
         if self.mock:
             return
@@ -69,7 +67,7 @@ class RTCInterface(object):
         try:
             self.ds3231 = SDL_DS3231.SDL_DS3231(1, 0x68, 0x57)
         except Exception, excpt:
-            self.logger.exception("Error initializing RTC. %s", excpt)
+            self.logger.exception("Error initializing RTC. %s." % excpt)
 
     def power_on_rtc(self):
         if self.mock:
@@ -96,7 +94,7 @@ class RTCInterface(object):
         try:
             return self.ds3231.read_datetime()
         except Exception, excpt:
-            self.logger.exception("Error getting RTC date/time. %s", excpt)
+            self.logger.exception("Error getting RTC date/time. %s." % excpt)
 
     def set_datetime(self):
         '''Writes the system datetime to the attached RTC if not mock.
@@ -108,7 +106,7 @@ class RTCInterface(object):
         try:
             self.ds3231.write_now()
         except Exception, excpt:
-            self.logger.exception("Error writing date/time to RTC. %s", excpt)
+            self.logger.exception("Error writing date/time to RTC. %s." % excpt)
 
     def get_temp(self):
         '''Gets the internal temperature from the RTC component
@@ -123,7 +121,7 @@ class RTCInterface(object):
         try:
             return self.ds3231.getTemp()
         except Exception, excpt:
-            self.logger.exception("Error getting the temperature from the RTC. %s", excpt)
+            self.logger.exception("Error getting the temperature from the RTC. %s." % excpt)
 
     def read_eeprom(self, address, n, name, mock_value):
         '''Return string of n bytes from EEPROM starting at address.
@@ -140,7 +138,7 @@ class RTCInterface(object):
                 for i in range(n)
             ]
         except Exception, excpt:
-            self.logger.exception("Error reading %s from EEPROM. %s", name, excpt)
+            self.logger.exception("Error reading %s from EEPROM. %s." % (name, excpt))
 
         s = ''.join(chr(c) for c in bytes_)
         return s.strip()
@@ -161,7 +159,7 @@ class RTCInterface(object):
             try:
                 self.ds3231.write_AT24C32_byte(address + i, ord(c))
             except Exception, excpt:
-                self.logger.exception("Error writing %s to EEPROM. %s", name, excpt)
+                self.logger.exception("Error writing %s to EEPROM. %s." % (name, excpt))
                 return
 
     def get_type(self):

--- a/src/smart_module/smart_module.py
+++ b/src/smart_module/smart_module.py
@@ -38,7 +38,6 @@ import logging
 import schedule                                     # sudo pip install schedule
 import communicator
 from influxdb import InfluxDBClient
-from influxdb.exceptions import InfluxDBClientError
 from status import SystemStatus
 import asset_interface
 import rtc_interface
@@ -231,11 +230,14 @@ class SmartModule(object):
         Create database if it does not already exist.
         Return the connection to the database."""
 
-        try:
-            self.ifconn.switch_database(database_name)
-        except InfluxDBClientError:
+        databases = self.ifconn.get_list_database()
+        for db in databases:
+            if database_name in db.values():
+                break
+        else:
             self.ifconn.create_database(database_name)
-            self.ifconn.switch_database(database_name)
+
+        self.ifconn.switch_database(database_name)
         return self.ifconn
 
     def push_sysinfo(self, asset_context, information):

--- a/src/smart_module/status.py
+++ b/src/smart_module/status.py
@@ -33,10 +33,10 @@ import datetime
 import psutil
 
 class SystemStatus(object):
-    """ Small class to handle system information """
+    """Small class to handle system information."""
 
     def __init__(self, update=False):
-        """ If please_update, create the object and fetch all data """
+        """If please_update, create the object and fetch all data."""
         self.cpu = {"percentage": 0}
         self.bootdate = 0
         self.memory = {"used": 0, "free": 0, "cached": 0}
@@ -54,7 +54,7 @@ class SystemStatus(object):
                      "clients": self.clients}])
 
     def update(self):
-        """ Function to update the entire class information """
+        """Function to update the entire class information."""
         self.cpu["percentage"] = psutil.cpu_percent(interval=0.7)
         self.boot = datetime.datetime.fromtimestamp(psutil.boot_time())\
                     .strftime("%Y-%m-%d %H:%M:%S")

--- a/src/smart_module/utilities.py
+++ b/src/smart_module/utilities.py
@@ -25,8 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import sys
 
 VERSION = "3.0 Alpha"
-SM_LOGGER = "smart_module"
-SC_LOGGER = "scheduler"
 DB_CORE = "hapi_core.db"
 DB_HIST = "hapi_history.db"
 SECONDS_PER_MINUTE = 60


### PR DESCRIPTION
I'm reverting last Jame's change on connecting and searching for the database in influxdb. It wasn't working with the latest library [you can check that on the comment I left on the pull request he made]. Of course, if we're missing something and the code really works, we should use it.

For more information check the commits' messages.
Important to reinforce: it still needs further tests.

Small test running smart_module.py:
```
$ python2.7 smart_module.py
2017-05-13 19:21:31.893275 - communicator.log - INFO - Communicator initialized
Mock Smart Module hosting asset  HSM-WT123-MOCK wt Environment
2017-05-13 19:21:31.896013 - smartmodule.log - INFO - Performing Discovery...
2017-05-13 19:21:31.896466 - smartmodule.log - INFO - Waiting Broker information on attempt: 1.
2017-05-13 19:21:32.897668 - smartmodule.log - INFO - MQTT Broker: ArchMain.local. IP: 192.168.0.99.
2017-05-13 19:21:32.898007 - communicator.log - INFO - Connecting to ArchMain.local. at 192.168.0.99.
2017-05-13 19:21:33.899359 - communicator.log - INFO - Connected with result code 0
$SYS/broker/clients/total 0
$SYS/broker/clients/total 1
2017-05-13 19:21:39.434406 - smartmodule.log - INFO - No Scheduler found. Becoming the Scheduler.
2017-05-13 19:21:39.434681 - scheduler.log - INFO - Loading Schedule Data...
2017-05-13 19:21:39.435394 - scheduler.log - INFO - Schedule Data Loaded.
2017-05-13 19:21:39.435500 - scheduler.log - INFO -   Loading seconds job: System Status.
2017-05-13 19:21:39.435953 - smartmodule.log - INFO - Scheduler program loaded.
2017-05-13 19:21:39.436571 - smartmodule.log - INFO - Site data loaded.
Running command self.smart_module.on_query_status()
STATUS/QUERY I might need to know how you are!
STATUS/RESPONSE [{'memory': {'cached': 1201475584, 'used': 1974157312, 'free': 505225216}, 'disk': {'total': 52472872960, 'free': 36937109504, 'used': 12839874560}, 'network': {'packet_recv': 3492089, 'packet_sent': 3405174}, 'time': 1494714110.150417, 'hostname': 'ArchMain', 'boot': '2017-05-12 22:04:25', 'cpu': {'percentage': 0.7}, 'clients': 1}]
Running command self.smart_module.on_query_status()
STATUS/QUERY I might need to know how you are!
STATUS/RESPONSE [{'memory': {'cached': 1201483776, 'used': 1973444608, 'free': 505917440}, 'disk': {'total': 52472872960, 'free': 36937101312, 'used': 12839882752}, 'network': {'packet_recv': 3492115, 'packet_sent': 3405201}, 'time': 1494714120.162569, 'hostname': 'ArchMain', 'boot': '2017-05-12 22:04:25', 'cpu': {'percentage': 1.1}, 'clients': 1}]
```
How the log is:
```
$ cat communicator.log scheduler.log smartmodule.log                                                                                                
2017-05-13 19:21:31.893275 - communicator.log - INFO - Communicator initialized
2017-05-13 19:21:32.898007 - communicator.log - INFO - Connecting to ArchMain.local. at 192.168.0.99.
2017-05-13 19:21:33.899359 - communicator.log - INFO - Connected with result code 0
2017-05-13 19:21:39.434681 - scheduler.log - INFO - Loading Schedule Data...
2017-05-13 19:21:39.435394 - scheduler.log - INFO - Schedule Data Loaded.
2017-05-13 19:21:39.435500 - scheduler.log - INFO -   Loading seconds job: System Status.
2017-05-13 19:21:31.896013 - smartmodule.log - INFO - Performing Discovery...
2017-05-13 19:21:31.896466 - smartmodule.log - INFO - Waiting Broker information on attempt: 1.
2017-05-13 19:21:32.897668 - smartmodule.log - INFO - MQTT Broker: ArchMain.local. IP: 192.168.0.99.
2017-05-13 19:21:39.434406 - smartmodule.log - INFO - No Scheduler found. Becoming the Scheduler.
2017-05-13 19:21:39.435953 - smartmodule.log - INFO - Scheduler program loaded.
2017-05-13 19:21:39.436571 - smartmodule.log - INFO - Site data loaded.

```