### PR TITLE
smart_module.py: Fixed logic bug.

### DIFF
--- a/src/smart_module/smart_module.py
+++ b/src/smart_module/smart_module.py
@@ -120,7 +120,7 @@ class SmartModule(object):
         """Check for published MQTT. If it finds port 1883 of type '_mqtt', update broker name."""
         # Get the service we want (port 1883 and type '_mqtt._tcp.local.'
         info = zeroconf.get_service_info(service_type, name)
-        if not info.port == 1883 and not service_type == "_mqtt._tcp.local.":
+        if not (info.port == 1883 and service_type == "_mqtt._tcp.local."):
             return
 
         if state_change is ServiceStateChange.Added:


### PR DESCRIPTION
There is more than one correct solution.
Maybe the following would work also.

    if info.port != 1883 or service_type != "_mqtt._tcp.local.":
        return

Use whichever is easier for you to understand.
From "The Zen of Python", readability counts.