### PR TITLE
communicator.py: Remove redundant str().

### DIFF
--- a/src/smart_module/alert.py
+++ b/src/smart_module/alert.py
@@ -73,7 +73,7 @@ class Alert(object):
             self.upper_threshold = float(self.upper_threshold)
             database.close()
         except Exception as excpt:
-            self.logger.exception("Error fetching alert parameters from database: %s." % excpt)
+            self.logger.exception("Error fetching alert parameters from database: %s.", excpt)
 
     def check_alert(self, current_value):
         """Check for alert to a given _value_."""

--- a/src/smart_module/asset_wt.py
+++ b/src/smart_module/asset_wt.py
@@ -40,7 +40,7 @@ class AssetImpl(object):
             self.log = log.Log("asset.log")
             print('Device file:', self.device_path)
         except Exception as excpt:
-            self.log.exception("Error initializing sensor interface: %s." % excpt)
+            self.log.exception("Error initializing sensor interface: %s.", excpt)
 
     def read_temp_raw(self):
         try:
@@ -50,7 +50,7 @@ class AssetImpl(object):
                     lines = lines + line.decode("utf-8")
             return lines.split("\n")
         except Exception as excpt:
-            self.log.exception("Error reading raw temperature data: %s." % excpt)
+            self.log.exception("Error reading raw temperature data: %s.", excpt)
 
     def read_value(self):
         temp_c = -50
@@ -66,6 +66,6 @@ class AssetImpl(object):
                 temp_c = float(temp_string) / 1000.0
 
         except Exception as excpt:
-            self.log.exception("Error getting converted sensor data: %s." % excpt)
+            self.log.exception("Error getting converted sensor data: %s.", excpt)
 
         return temp_c

--- a/src/smart_module/communicator.py
+++ b/src/smart_module/communicator.py
@@ -50,7 +50,7 @@ class Communicator(object):
             self.logger.info("Connecting to %s at %s." % (self.broker_name, self.broker_ip))
             self.client.connect(host=self.broker_ip, port=1883, keepalive=60)
         except Exception as excpt:
-            self.logger.exception("[Exiting] Error connecting to broker: %s" % excpt)
+            self.logger.exception("[Exiting] Error connecting to broker: %s", excpt)
             sys.exit(-1)
 
     def subscribe(self, topic):
@@ -146,4 +146,4 @@ class Communicator(object):
             if self.client:
                 self.client.publish(topic, message)
         except Exception as excpt:
-            self.logger.info("Error publishing message: %s." % excpt)
+            self.logger.info("Error publishing message: %s.", excpt)

--- a/src/smart_module/communicator.py
+++ b/src/smart_module/communicator.py
@@ -71,7 +71,7 @@ class Communicator(object):
     # The callback for when the client receives a CONNACK response from the server.
     #@staticmethod
     def on_connect(self, client, userdata, flags, rc):
-        self.logger.info("Connected with result code %s" % rc)
+        self.logger.info("Connected with result code %s", rc)
         # Subscribing in on_connect() means if we lose connection and reconnect, subscriptions will
         # be renewed.
         #self.client.subscribe("SCHEDULER/LOCATE")

--- a/src/smart_module/communicator.py
+++ b/src/smart_module/communicator.py
@@ -71,7 +71,7 @@ class Communicator(object):
     # The callback for when the client receives a CONNACK response from the server.
     #@staticmethod
     def on_connect(self, client, userdata, flags, rc):
-        self.logger.info("Connected with result code %s", rc)
+        self.logger.info("Connected with result code %s" % rc)
         # Subscribing in on_connect() means if we lose connection and reconnect, subscriptions will
         # be renewed.
         #self.client.subscribe("SCHEDULER/LOCATE")

--- a/src/smart_module/communicator.py
+++ b/src/smart_module/communicator.py
@@ -71,7 +71,7 @@ class Communicator(object):
     # The callback for when the client receives a CONNACK response from the server.
     #@staticmethod
     def on_connect(self, client, userdata, flags, rc):
-        self.logger.info("Connected with result code %s" % str(rc))
+        self.logger.info("Connected with result code %s", rc)
         # Subscribing in on_connect() means if we lose connection and reconnect, subscriptions will
         # be renewed.
         #self.client.subscribe("SCHEDULER/LOCATE")

--- a/src/smart_module/log.py
+++ b/src/smart_module/log.py
@@ -48,9 +48,9 @@ class Log(object):
         )
         return str(string)
 
-    def info(self, information):
+    def info(self, information, *args):
         """Append INFO in information to file. Accepts a single string."""
-        string = self.build_string("INFO", information)
+        string = self.build_string("INFO", information % args)
         with open(self.log_file, "a") as log:
             log.write(string + "\n")
         print(string)

--- a/src/smart_module/log.py
+++ b/src/smart_module/log.py
@@ -48,16 +48,16 @@ class Log(object):
         )
         return str(string)
 
-    def info(self, information, *args):
-        """Append INFO in information to file. Accepts a single string."""
-        string = self.build_string("INFO", information % args)
+    def info(self, format, *values):
+        """Append INFO in format % values to file."""
+        string = self.build_string("INFO", format % values)
         with open(self.log_file, "a") as log:
             log.write(string + "\n")
         print(string)
 
-    def exception(self, information):
-        """Append ERROR in information to file. Accepts a single string."""
-        string = self.build_string("[!!] ERROR", information)
+    def exception(self, format, *values):
+        """Append ERROR in format % values to file."""
+        string = self.build_string("[!!] ERROR", format % values)
         with open(self.log_file, "a") as log:
             log.write(string + "\n")
         print(string)

--- a/src/smart_module/rtc_interface.py
+++ b/src/smart_module/rtc_interface.py
@@ -67,7 +67,7 @@ class RTCInterface(object):
         try:
             self.ds3231 = SDL_DS3231.SDL_DS3231(1, 0x68, 0x57)
         except Exception as excpt:
-            self.logger.exception("Error initializing RTC. %s." % excpt)
+            self.logger.exception("Error initializing RTC. %s.", excpt)
 
     def power_on_rtc(self):
         if self.mock:
@@ -94,7 +94,7 @@ class RTCInterface(object):
         try:
             return self.ds3231.read_datetime()
         except Exception as excpt:
-            self.logger.exception("Error getting RTC date/time. %s." % excpt)
+            self.logger.exception("Error getting RTC date/time. %s.", excpt)
 
     def set_datetime(self):
         '''Writes the system datetime to the attached RTC if not mock.
@@ -106,7 +106,7 @@ class RTCInterface(object):
         try:
             self.ds3231.write_now()
         except Exception as excpt:
-            self.logger.exception("Error writing date/time to RTC. %s." % excpt)
+            self.logger.exception("Error writing date/time to RTC. %s.", excpt)
 
     def get_temp(self):
         '''Gets the internal temperature from the RTC component
@@ -121,7 +121,7 @@ class RTCInterface(object):
         try:
             return self.ds3231.getTemp()
         except Exception as excpt:
-            self.logger.exception("Error getting the temperature from the RTC. %s." % excpt)
+            self.logger.exception("Error getting the temperature from the RTC. %s.", excpt)
 
     def read_eeprom(self, address, n, name, mock_value):
         '''Return string of n bytes from EEPROM starting at address.

--- a/src/smart_module/smart_module.py
+++ b/src/smart_module/smart_module.py
@@ -114,7 +114,7 @@ class SmartModule(object):
             # We will change it soon!
             os.system("sudo systemctl start avahi-daemon.service")
         except Exception as excpt:
-            self.log.info("Error trying to become the Broker: %s." % excpt)
+            self.log.info("Error trying to become the Broker: %s.", excpt)
 
     def find_service(self, zeroconf, service_type, name, state_change):
         """Check for published MQTT. If it finds port 1883 of type '_mqtt', update broker name."""
@@ -197,7 +197,7 @@ class SmartModule(object):
                 self.comm.send("ANNOUNCE", self.hostname + ".local is running the Scheduler.")
                 self.log.info("Scheduler program loaded.")
             except Exception as excpt:
-                self.log.exception("Error initializing scheduler. %s." % excpt)
+                self.log.exception("Error initializing scheduler. %s.", excpt)
 
     def load_site_data(self):
         field_names = '''
@@ -224,7 +224,7 @@ class SmartModule(object):
             database.close()
             self.log.info("Site data loaded.")
         except Exception as excpt:
-            self.log.exception("Error loading site data: %s." % excpt)
+            self.log.exception("Error loading site data: %s.", excpt)
 
     def connect_influx(self, database_name):
         """Connect to database named database_name on InfluxDB server.
@@ -296,7 +296,7 @@ class SmartModule(object):
             sysinfo.clients = brokerconnections
             return sysinfo
         except Exception as excpt:
-            self.log.exception("Error getting System Status: %s." % excpt)
+            self.log.exception("Error getting System Status: %s.", excpt)
 
     def on_query_status(self):
         """It'll be called by the Scheduler to ask for System Status information."""
@@ -310,7 +310,7 @@ class SmartModule(object):
         try:
             value = str(self.ai.read_value())
         except Exception as excpt:
-            self.log.exception("Error getting asset data: %s." % excpt)
+            self.log.exception("Error getting asset data: %s.", excpt)
             value = -1000
 
         return value
@@ -321,7 +321,7 @@ class SmartModule(object):
                 self.push_data(self.asset.name, self.asset.context, self.asset.value,
                                self.asset.unit)
             except Exception as excpt:
-                self.log.exception("Error logging sensor data: %s." % excpt)
+                self.log.exception("Error logging sensor data: %s.", excpt)
         else:
             # For virtual assets, assume that the data is already parsed JSON
             unit_symbol = {
@@ -335,7 +335,7 @@ class SmartModule(object):
                     self.push_data(factor, "Environment", value, unit_symbol[factor])
 
             except Exception as excpt:
-                self.log.exception("Error logging sensor data: %s." % excpt)
+                self.log.exception("Error logging sensor data: %s.", excpt)
 
     def push_data(self, asset_name, asset_context, value, unit):
         try:
@@ -357,7 +357,7 @@ class SmartModule(object):
             conn.write_points(json_body)
             self.log.info("Wrote to analytic database: %s." % json_body)
         except Exception as excpt:
-            self.log.exception("Error writing to analytic database: %s." % excpt)
+            self.log.exception("Error writing to analytic database: %s.", excpt)
 
     def get_weather(self):
         response = ""
@@ -377,7 +377,7 @@ class SmartModule(object):
             response = parsed_json['current_observation']
             f.close()
         except Exception as excpt:
-            self.log.exception("Error getting weather data: %s." % excpt)
+            self.log.exception("Error getting weather data: %s.", excpt)
         return response
 
     def log_command(self, job, result):
@@ -393,7 +393,7 @@ class SmartModule(object):
             database.commit()
             database.close()
         except Exception as excpt:
-            self.log.exception("Error logging command: %s." % excpt)
+            self.log.exception("Error logging command: %s.", excpt)
 
     def get_env(self):
         now = datetime.datetime.now()
@@ -430,7 +430,7 @@ class SmartModule(object):
         try:
             self.comm.send("ENV/RESPONSE", s)
         except Exception as excpt:
-            self.log.exception("Error getting environment data: %s." % excpt)
+            self.log.exception("Error getting environment data: %s.", excpt)
 
 class Scheduler(object):
     def __init__(self):
@@ -499,7 +499,7 @@ class Scheduler(object):
             database.close()
             self.log.info("Schedule Data Loaded.")
         except Exception as excpt:
-            self.log.exception("Error loading schedule. %s." % excpt)
+            self.log.exception("Error loading schedule. %s.", excpt)
 
         return jobs
 
@@ -550,7 +550,7 @@ class Scheduler(object):
                 response = eval(job.command)
                 self.smart_module.log_sensor_data(response, True)
             except Exception as excpt:
-                self.log.exception("Error running job. %s." % excpt)
+                self.log.exception("Error running job. %s.", excpt)
         else:
             try:
                 if job.sequence != "":
@@ -586,7 +586,7 @@ class Scheduler(object):
                     #self.log_command(job, "")
 
             except Exception as excpt:
-                self.log.exception("Error running job: %s." % excpt)
+                self.log.exception("Error running job: %s.", excpt)
 
 class DataSync(object):
     log = log.Log("datasync.log")
@@ -603,7 +603,7 @@ class DataSync(object):
             DataSync.log.info("Read database version: %s." % version)
             return version
         except Exception as excpt:
-            DataSync.log.exception("Error reading database version: %s." % excpt)
+            DataSync.log.exception("Error reading database version: %s.", excpt)
 
     @staticmethod
     def write_db_version():
@@ -616,7 +616,7 @@ class DataSync(object):
             database.close()
             DataSync.log.info("Wrote database version: %s." % version)
         except Exception as excpt:
-            DataSync.log.exception("Error writing database version: %s." % excpt)
+            DataSync.log.exception("Error writing database version: %s.", excpt)
 
     @staticmethod
     def publish_core_db(comm):
@@ -635,7 +635,7 @@ class DataSync(object):
             #comm.subscribe("SYNCHRONIZE/DATA")
             DataSync.log.info("Published database.")
         except Exception as excpt:
-            DataSync.log.exception("Error publishing database: %s." % excpt)
+            DataSync.log.exception("Error publishing database: %s.", excpt)
 
     def synchronize_core_db(self, data):
         try:
@@ -648,7 +648,7 @@ class DataSync(object):
 
             DataSync.log.info("Synchronized database.")
         except Exception as excpt:
-            DataSync.log.exception("Error synchronizing database: %s." % excpt)
+            DataSync.log.exception("Error synchronizing database: %s.", excpt)
 
 def main():
     #max_log_size = 1000000
@@ -680,7 +680,7 @@ def main():
         smart_module.load_site_data()
 
     except Exception as excpt:
-        logging.exception("Error initializing Smart Module. %s." % excpt)
+        logging.exception("Error initializing Smart Module. %s.", excpt)
 
     while 1:
         try:
@@ -688,7 +688,7 @@ def main():
             schedule.run_pending()
 
         except Exception as excpt:
-            logging.exception("Error in Smart Module main loop. %s." % excpt)
+            logging.exception("Error in Smart Module main loop. %s.", excpt)
             break
 
 if __name__ == "__main__":


### PR DESCRIPTION
%s performs str() in all of the following.
The explicit str() in the first one is redundant.
The comma in the last one is allowed by the logging module, IIRC.

    self.logger.info("Connected with result code %s" % str(rc))
    self.logger.info("Connected with result code %s" % rc)
    self.logger.info("Connected with result code %s", rc)