### PR TITLE
hapi_sensors.ino: Use ArrayLength(pinControl) instead of NUM_DIGITAL+NUM_ANALOG.

### DIFF
--- a/src/dumb_module/arduino/hapinode/hapi_sensors.ino
+++ b/src/dumb_module/arduino/hapinode/hapi_sensors.ino
@@ -79,7 +79,7 @@ void setupSensors(void){
 String getPinArray() {
   // Returns all pin configuration information
   String response = "";
-  for (int i = 0; i < NUM_DIGITAL+NUM_ANALOG; i++) {
+  for (int i = 0; i < ArrayLength(pinControl); i++) {
     if (i <= (NUM_DIGITAL-1)) {
       response += String(i) + String(pinControl[i]);
     }


### PR DESCRIPTION
Say what you mean, simply and directly.
The Elements of Programming Style