### PR TITLE
Update install docs to include command lines

### DIFF
--- a/docs/HAPImodule.rst
+++ b/docs/HAPImodule.rst
@@ -28,14 +28,37 @@ Note: Soon we'll introduce configuration via regular file and/or database. For n
 1. Install `Raspbian <https://www.raspberrypi.org/downloads/raspbian/>`_ on the Raspberry Pi
 
   * `Raspbian installation guide <https://www.raspberrypi.org/documentation/installation/installing-images/README.md>`_.
+  
+  * **Configure Raspbian Jessie**
+  
+      * At minimum, using ssh or graphical shell:
+      
+        .. code:: shell
+        
+            sudo raspi-config      
+      
+      * Set password
+      * Set hostname (e.g.HAPImodule001)
+      * Set locale
+      * Set keyboard
+      * Set timezone
+      * Set wifi - country, ssid, and password
+      
+      * Reboot
 
 2. Install dependencies on the Pi
 
   * Dependencies:
 
-    * **Avahi** (daemon) configured to publish MQTT service.
+    * **Avahi** (daemon) configured to publish MQTT service. avahi is already installed on Raspi Jessie.
 
       * :download:`Example config <example_configs/avahi-example>`
+      * Copy the file to the config directory and rename it:
+      
+        .. code:: shell
+        
+            sudo cp ~/Downloads/avahi-example /etc/avahi/services/multiple.service
+            
       * Restart to apply changes:
 
         .. code:: shell
@@ -44,12 +67,89 @@ Note: Soon we'll introduce configuration via regular file and/or database. For n
 
     * **MQTT Mosquitto** with default configuration.
 
+      * Install mosquitto
+       
+        .. code:: shell
+        
+            sudo apt-get install mosquitto     
+
       * :download:`Example config <example_configs/mosquitto-example>`
+      * Copy the file to the config directory and rename it:
+      
+        .. code:: shell
+        
+            sudo cp ~/Downloads/mosquitto-example /etc/mosquitto/conf.d/mosquitto.conf
+            
+      * Start mosquitto to apply config, and set mosquitto to start on boot:
+
+        .. code:: shell
+
+            sudo systemctl start mosquitto
+            sudo systemctl enable mosquitto
 
     * **Influxdb** with default configuration.
-    * **Grafana** [Optional] (highly recommended).
+        `https://easysquirrel.io/index.php/2017/03/20/influxdb-and-telegraf-on-raspberry-pi-3/`
+        `http://docs.influxdata.com/influxdb/v1.2/introduction/installation`
+        
+        * the configuration file is located at /etc/influxdb/influxdb.conf for default installations  
+        * test by typing 'influx' at the command line  
 
-  * There is also a script from the repo for installing the first two system dependencies and then setup the python environment:
+      * **add influxdb repository**
+
+        .. code:: shell
+
+          curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
+          source /etc/os-release
+          test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+          test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
+
+      * Install libfontconfig1 (required)
+
+        .. code:: shell
+
+          sudo apt-get install libfontconfig1
+          sudo apt-get -f install
+            
+      * **influxdb**
+
+        .. code:: shell
+
+          sudo apt-get update && sudo apt-get install influxdb
+          sudo service influxdb start 
+
+      * **Telegraf**
+
+        .. code:: shell
+
+          sudo apt-get update && sudo apt-get install telegraf
+          sudo service telegraf start
+
+    * **Grafana** [Optional] (highly recommended)
+    
+        .. code:: shell
+        
+          cd ~
+          wget --output-document=grafana_4.2.0-beta1_armhf.deb https://bintray.com/fg2it/deb/download_file?file_path=testing%2Fg%2Fgrafana_4.2.0-beta1_armhf.deb
+          sudo dpkg -i grafana_4.2.0-beta1_armhf.deb
+          sudo apt-get install -f
+
+    * Enable Grafana for automatic start on boot and start the server
+    
+        .. code:: shell
+        
+          sudo systemctl enable grafana-server
+          sudo systemctl start grafana-server
+
+    * Reboot your Raspberry Pi
+
+        .. code:: shell
+        
+          sudo reboot    
+ 
+3. Install hapi
+
+  * **Install hapi dependencies on the Pi** 
+    * There is also a script from the repo for installing the first two system dependencies and then setup the python environment:
 
       .. code:: shell
 


### PR DESCRIPTION
I have installed using these commands, and successfully started smart_module.py.
There was a problem with pip:
```

pi@HAPIModule001:~ $ sudo apt-get install git
Reading package lists... Done
Building dependency tree
Reading state information... Done
git is already the newest version.
git set to manually installed.
0 upgraded, 0 newly installed, 0 to remove and 4 not upgraded.
pi@HAPIModule001:~ $ cd ~
pi@HAPIModule001:~ $ git clone https://github.com/mayaculpa/hapi.git
Cloning into 'hapi'...
remote: Counting objects: 2558, done.
remote: Compressing objects: 100% (27/27), done.
remote: Total 2558 (delta 13), reused 36 (delta 12), pack-reused 2519
Receiving objects: 100% (2558/2558), 3.81 MiB | 1.43 MiB/s, done.
Resolving deltas: 100% (1330/1330), done.
Checking connectivity... done.
pi@HAPIModule001:~ $ cd ~/hapi/src/smart_module
pi@HAPIModule001:~/hapi/src/smart_module $ ./INSTALL.sh

Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    load_entry_point('pip==1.5.6', 'console_scripts', 'pip')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 356, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2476, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2190, in load
    ['__name__'])
  File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 74, in <module>
    from pip.vcs import git, mercurial, subversion, bazaar  # noqa
  File "/usr/lib/python2.7/dist-packages/pip/vcs/mercurial.py", line 9, in <module>
    from pip.download import path_to_url
  File "/usr/lib/python2.7/dist-packages/pip/download.py", line 25, in <module>
    from requests.compat import IncompleteRead
ImportError: cannot import name IncompleteRead
./INSTALL.sh: line 9: virtualenv: command not found
./INSTALL.sh: line 10: env/bin/activate: No such file or directory

```

 It was solved by removing and re-installing pip.
It is a known problem, but I don't know why it is there on a fresh install of Jessie.
I don't understand it, but there is a lot of discussion about it on the web.