### PR TITLE
Updated INSTALL.sh, requirements.txt

### DIFF
--- a/src/smart_module/INSTALL.sh
+++ b/src/smart_module/INSTALL.sh
@@ -11,8 +11,10 @@ VIRTUAL_ENV="false"
 VIRTUAL_PATH=""
 
 # System packages
-NECESSARY_PACKAGES=('avahi-daemon' 'python-dev' 'python-pip' 'mosquitto')
-# We still need influxdb and maybe grafana
+NECESSARY_PACKAGES=('avahi-daemon' 'python-dev' 'python-pip' 'mosquitto' 'sqlite3')
+
+# File dependencies
+file="./SDL_DS3231.py"
 
 # Information output, same as echo but with timestamp
 info() { echo "[*] [$(date)] : $*"; }
@@ -30,19 +32,21 @@ main() {
                 info "Error. You didn't provide a path for virtualenv."
                 exit -1
             fi
+	    VIRTUAL_PATH="$2"
             ;;
     esac
 
     # Installing necessary system packages. python-dev needed for RPi.GPIO
-    info "Installing necessay system packages: ${NECESSARY_PACKAGES[*]}"
-    apt-get install "$*"
+    info "Installing necessary system packages: ${NECESSARY_PACKAGES[*]}"
+    info sudo apt-get install "${NECESSARY_PACKAGES[*]}"
+    sudo apt-get install ${NECESSARY_PACKAGES[*]}
 
     if [ "$VIRTUAL_ENV" == "true" ]; then
         info "Enabling virtualenv at $VIRTUAL_PATH"
         # virtualenv for legacy Python (i.e., Python 2)
         # sudo apt-get install virtualenv ;# use pip instead
         virtualenv "$VIRTUAL_PATH"
-        source "${VIRTUAL_PATH}/bin/activate"
+        source "${VIRTUAL_PATH}"/bin/activate
     fi
 
     info "Installing python modules..."
@@ -50,8 +54,13 @@ main() {
 
     # Installing a lone file from a project is ugly and suspicious.
     # Following needed only if running on real mode (with actual sensor data).
-    info "Fetching SDL module..."
-    wget https://raw.githubusercontent.com/switchdoclabs/RTC_SDL_DS3231/master/SDL_DS3231.py
+    info "Checking SDL module..."
+    if [ -e "$file" ]; then
+      info " SDL file exists"
+    else 
+      info " Fetching SDL_DS3231.py from github"
+      wget https://raw.githubusercontent.com/switchdoclabs/RTC_SDL_DS3231/master/SDL_DS3231.py
+    fi
 }
 
 main "$@"

--- a/src/smart_module/requirements.txt
+++ b/src/smart_module/requirements.txt
@@ -17,5 +17,6 @@ requests==2.16.5
 RPi.GPIO==0.6.3
 schedule==0.4.2
 six==1.10.0
+twilio==6.4.2
 urllib3==1.21.1
 zeroconf==0.19.0


### PR DESCRIPTION
'source virtualenv' doesn't work within the bash shell, as the bash shell exits and resets the environment
I tried 'source INSTALL.sh' which seems to work but results in unusual behaviour, so I fear it is NOT the solution.
grafana, telegraf and influxdb are still outstanding as they require external repositories to 'jessie'