### PR TITLE
Remove the man folder

### DIFF
--- a/man/README.md
+++ b/man/README.md
@@ -1,4 +1,0 @@
-# Manual pages
-
-This folder will contain all the manual pages.
-Soon!


### PR DESCRIPTION
Closes #135

- It is currently not used
- Designed for unix man pages. This format has be superseeded by Markdown and online docs with RST
- Man pages mainly used for programs installed via debs/rpms